### PR TITLE
Revert "[BTAT-2953] changed header and postcode label for address lookup page"

### DIFF
--- a/app/models/customerAddress/AddressLookupJsonBuilder.scala
+++ b/app/models/customerAddress/AddressLookupJsonBuilder.scala
@@ -28,13 +28,9 @@ case class AddressLookupJsonBuilder(continueUrl: String) {
   // lookup page overrides
   val lookupPage = Map(
     "title" -> "Changes in circumstances",
-    "heading" -> "Select the new business address",
-    "filterLabel" -> "Property name or number",
-    "postcodeLabel" -> "Postcode"
-  )
-
-  val confirmPage = Map(
-    "heading" -> "Confirm the new business address"
+    "heading" -> "What is the new business address?",
+    "filterLabel" -> "Property name or number"
+//    "manualAddressLinkText" -> "bob" // ignored whilst ukMode == true?
   )
 }
 
@@ -48,9 +44,7 @@ object AddressLookupJsonBuilder {
         "navTitle" -> data.navTitle,
         "ukMode" -> data.ukMode,
 
-        "lookupPage" -> data.lookupPage,
-
-        "confirmPage" -> data.confirmPage
+        "lookupPage" -> data.lookupPage
       )
     }
   }

--- a/test/assets/CustomerAddressTestConstants.scala
+++ b/test/assets/CustomerAddressTestConstants.scala
@@ -112,12 +112,8 @@ object CustomerAddressTestConstants {
     "showPhaseBanner" -> true,
     "lookupPage" -> Json.obj(
       "title" -> "Changes in circumstances",
-      "heading" -> "Select the new business address",
-      "filterLabel" -> "Property name or number",
-      "postcodeLabel" -> "Postcode"
-    ),
-    "confirmPage" -> Json.obj(
-      "heading" -> "Confirm the new business address"
+      "heading" -> "What is the new business address?",
+      "filterLabel" -> "Property name or number"
     )
   )
 


### PR DESCRIPTION
Reverts hmrc/manage-vat-subscription-frontend#110

Require's AT change before merging.