### PR TITLE
[BTAT-2953] changed header and postcode label for address lookup page

### DIFF
--- a/app/models/customerAddress/AddressLookupJsonBuilder.scala
+++ b/app/models/customerAddress/AddressLookupJsonBuilder.scala
@@ -33,6 +33,10 @@ case class AddressLookupJsonBuilder(continueUrl: String) {
     "postcodeLabel" -> "Postcode"
   )
 
+  val selectPage = Map(
+    "submitLabel" -> "Save and continue"
+  )
+
   val confirmPage = Map(
     "heading" -> "Confirm the new business address"
   )
@@ -49,6 +53,8 @@ object AddressLookupJsonBuilder {
         "ukMode" -> data.ukMode,
 
         "lookupPage" -> data.lookupPage,
+
+        "selectPage" -> data.selectPage,
 
         "confirmPage" -> data.confirmPage
       )

--- a/app/models/customerAddress/AddressLookupJsonBuilder.scala
+++ b/app/models/customerAddress/AddressLookupJsonBuilder.scala
@@ -28,9 +28,13 @@ case class AddressLookupJsonBuilder(continueUrl: String) {
   // lookup page overrides
   val lookupPage = Map(
     "title" -> "Changes in circumstances",
-    "heading" -> "What is the new business address?",
-    "filterLabel" -> "Property name or number"
-//    "manualAddressLinkText" -> "bob" // ignored whilst ukMode == true?
+    "heading" -> "Select the new business address",
+    "filterLabel" -> "Property name or number",
+    "postcodeLabel" -> "Postcode"
+  )
+
+  val confirmPage = Map(
+    "heading" -> "Confirm the new business address"
   )
 }
 
@@ -44,7 +48,9 @@ object AddressLookupJsonBuilder {
         "navTitle" -> data.navTitle,
         "ukMode" -> data.ukMode,
 
-        "lookupPage" -> data.lookupPage
+        "lookupPage" -> data.lookupPage,
+
+        "confirmPage" -> data.confirmPage
       )
     }
   }

--- a/app/models/customerAddress/AddressLookupJsonBuilder.scala
+++ b/app/models/customerAddress/AddressLookupJsonBuilder.scala
@@ -28,7 +28,7 @@ case class AddressLookupJsonBuilder(continueUrl: String) {
   // lookup page overrides
   val lookupPage = Map(
     "title" -> "Changes in circumstances",
-    "heading" -> "Select the new business address",
+    "heading" -> "What is the new business address?",
     "filterLabel" -> "Property name or number",
     "postcodeLabel" -> "Postcode"
   )

--- a/app/models/customerAddress/AddressLookupJsonBuilder.scala
+++ b/app/models/customerAddress/AddressLookupJsonBuilder.scala
@@ -34,6 +34,7 @@ case class AddressLookupJsonBuilder(continueUrl: String) {
   )
 
   val selectPage = Map(
+    "heading" -> "Select the new business address",
     "submitLabel" -> "Save and continue"
   )
 

--- a/test/assets/CustomerAddressTestConstants.scala
+++ b/test/assets/CustomerAddressTestConstants.scala
@@ -116,6 +116,9 @@ object CustomerAddressTestConstants {
       "filterLabel" -> "Property name or number",
       "postcodeLabel" -> "Postcode"
     ),
+    "selectPage" -> Json.obj(
+      "submitLabel" -> "Save and continue"
+    ),
     "confirmPage" -> Json.obj(
       "heading" -> "Confirm the new business address"
     )

--- a/test/assets/CustomerAddressTestConstants.scala
+++ b/test/assets/CustomerAddressTestConstants.scala
@@ -112,8 +112,12 @@ object CustomerAddressTestConstants {
     "showPhaseBanner" -> true,
     "lookupPage" -> Json.obj(
       "title" -> "Changes in circumstances",
-      "heading" -> "What is the new business address?",
-      "filterLabel" -> "Property name or number"
+      "heading" -> "Select the new business address",
+      "filterLabel" -> "Property name or number",
+      "postcodeLabel" -> "Postcode"
+    ),
+    "confirmPage" -> Json.obj(
+      "heading" -> "Confirm the new business address"
     )
   )
 

--- a/test/assets/CustomerAddressTestConstants.scala
+++ b/test/assets/CustomerAddressTestConstants.scala
@@ -112,7 +112,7 @@ object CustomerAddressTestConstants {
     "showPhaseBanner" -> true,
     "lookupPage" -> Json.obj(
       "title" -> "Changes in circumstances",
-      "heading" -> "Select the new business address",
+      "heading" -> "What is the new business address?",
       "filterLabel" -> "Property name or number",
       "postcodeLabel" -> "Postcode"
     ),

--- a/test/assets/CustomerAddressTestConstants.scala
+++ b/test/assets/CustomerAddressTestConstants.scala
@@ -117,6 +117,7 @@ object CustomerAddressTestConstants {
       "postcodeLabel" -> "Postcode"
     ),
     "selectPage" -> Json.obj(
+      "heading" -> "Select the new business address",
       "submitLabel" -> "Save and continue"
     ),
     "confirmPage" -> Json.obj(


### PR DESCRIPTION
Reverts hmrc/manage-vat-subscription-frontend#112

Re-raised; this cannot be merged until the AT task has been completed.

https://github.com/hmrc/change-vat-acceptance-tests/pull/23