### PR TITLE
[BTAT-3754] Updated GA tracking for Agent/Non-Agent to use url params instead of Query Strings

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -94,7 +94,7 @@ class FrontendAppConfig @Inject()(val runModeConfiguration: Configuration, envir
 
   override lazy val signInContinueBaseUrl: String = getString(Keys.signInContinueBaseUrl)
   private lazy val signInContinueUrl: String =
-    ContinueUrl(signInContinueBaseUrl + controllers.routes.CustomerCircumstanceDetailsController.show(None).url).encodedUrl
+    ContinueUrl(signInContinueBaseUrl + controllers.routes.CustomerCircumstanceDetailsController.redirect.url).encodedUrl
 
   private lazy val signInOrigin = getString(Keys.appName)
   override lazy val signInUrl: String = s"$signInBaseUrl?continue=$signInContinueUrl&origin=$signInOrigin"

--- a/app/controllers/BusinessAddressController.scala
+++ b/app/controllers/BusinessAddressController.scala
@@ -51,7 +51,7 @@ class BusinessAddressController @Inject()(val messagesApi: MessagesApi,
       case Right(address) =>
         ppobService.updatePPOB(user, address, id) map {
           case Right(_) =>
-            Redirect(controllers.routes.BusinessAddressController.confirmation(user.isAgent))
+            Redirect(controllers.routes.BusinessAddressController.confirmation(user.redirectSuffix))
           case Left(_) => Logger.debug(s"[BusinessAddressController][callback] Error Returned from PPOB Service, Rendering ISE.")
             serviceErrorHandler.showInternalServerError
         }
@@ -60,7 +60,7 @@ class BusinessAddressController @Inject()(val messagesApi: MessagesApi,
     }
   }
 
-  val confirmation: Boolean => Action[AnyContent] = _ => authenticate.async { implicit user =>
+  val confirmation: String => Action[AnyContent] = _ => authenticate.async { implicit user =>
     Future.successful(Ok(views.html.businessAddress.change_address_confirmation()))
   }
 }

--- a/app/controllers/predicates/AuthoriseAsAgentOnly.scala
+++ b/app/controllers/predicates/AuthoriseAsAgentOnly.scala
@@ -51,7 +51,7 @@ class AuthoriseAsAgentOnly @Inject()(enrolmentsAuthService: EnrolmentsAuthServic
               checkAgentEnrolment(allEnrolments, f)
             case (_, _) =>
               Logger.debug("[AuthoriseAsAgentOnly][invokeBlock] - Is NOT an Agent, redirecting to Customer Details page")
-              Future.successful(Redirect(controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false))))
+              Future.successful(Redirect(controllers.routes.CustomerCircumstanceDetailsController.show("non-agent")))
           }
         }
         case _ =>

--- a/app/controllers/returnFrequency/ChangeReturnFrequencyConfirmation.scala
+++ b/app/controllers/returnFrequency/ChangeReturnFrequencyConfirmation.scala
@@ -31,7 +31,7 @@ class ChangeReturnFrequencyConfirmation @Inject()(val messagesApi: MessagesApi,
                                                   val serviceErrorHandler: ServiceErrorHandler,
                                                   implicit val appConfig: AppConfig) extends FrontendController with I18nSupport {
 
-  val show: Boolean => Action[AnyContent] = isAgent => authenticate.async { implicit user =>
+  val show: String => Action[AnyContent] = _ => authenticate.async { implicit user =>
     Future.successful(Ok(views.html.returnFrequency.change_return_frequency_confirmation()))
   }
 }

--- a/app/controllers/returnFrequency/ConfirmVatDatesController.scala
+++ b/app/controllers/returnFrequency/ConfirmVatDatesController.scala
@@ -54,7 +54,7 @@ class ConfirmVatDatesController @Inject()(val authenticate: AuthPredicate,
               UpdateReturnFrequencyAuditModel(user, currentFrequency, newFrequency, success.formBundle),
               Some(controllers.returnFrequency.routes.ConfirmVatDatesController.submit().url)
             )
-            Redirect(controllers.returnFrequency.routes.ChangeReturnFrequencyConfirmation.show(user.isAgent))
+            Redirect(controllers.returnFrequency.routes.ChangeReturnFrequencyConfirmation.show(if(user.isAgent) "agent" else "non-agent"))
               .removingFromSession(SessionKeys.NEW_RETURN_FREQUENCY, SessionKeys.CURRENT_RETURN_FREQUENCY)
           }
           case _ => serviceErrorHandler.showInternalServerError

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -21,6 +21,7 @@ import uk.gov.hmrc.auth.core.{Enrolment, EnrolmentIdentifier, Enrolments, Intern
 
 case class User[A](vrn: String, active: Boolean = true, arn: Option[String] = None) (implicit request: Request[A]) extends WrappedRequest[A](request) {
   val isAgent: Boolean = arn.isDefined
+  val redirectSuffix: String = if(isAgent) "agent" else "non-agent"
 }
 
 object User {

--- a/app/services/PaymentsService.scala
+++ b/app/services/PaymentsService.scala
@@ -36,15 +36,15 @@ class PaymentsService @Inject()(paymentsConnector: PaymentsConnector) {
       if(user.isAgent) {
         config.host + controllers.agentClientRelationship.routes.SelectClientVrnController.show()
       } else {
-        config.host + controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent))
+        config.host + controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix)
       }
     }
 
     val paymentDetails: PaymentStartModel = PaymentStartModel(
       user.vrn,
       user.isAgent,
-      config.host + controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent)),
-      config.host + controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent)),
+      config.host + controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix),
+      config.host + controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix),
       convenienceUrl
     )
 

--- a/app/views/agentClientRelationship/confirm_client_vrn.scala.html
+++ b/app/views/agentClientRelationship/confirm_client_vrn.scala.html
@@ -34,7 +34,7 @@
     <p>@vrn</p>
 
     <a onclick="sendGAEvent('select-client','confirm','confirm-client-vat-number', true)"
-       href="@controllers.routes.CustomerCircumstanceDetailsController.show(Some(true))"
+       href='@controllers.routes.CustomerCircumstanceDetailsController.show("agent")'
        class="button form-group">
         @messages("common.confirmAndContinue")
     </a>

--- a/app/views/businessAddress/change_address_confirmation.scala.html
+++ b/app/views/businessAddress/change_address_confirmation.scala.html
@@ -43,7 +43,7 @@
 
     <a onclick="sendGAEvent('business-address','finish','change-business-address-confirmation', @user.isAgent)"
        id="finish"
-       href='@controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent))'
+       href='@controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix)'
        class="button"
        type="submit">
         @messages("common.finish")

--- a/app/views/helpers/back_to_business_details.scala.html
+++ b/app/views/helpers/back_to_business_details.scala.html
@@ -15,4 +15,4 @@
  *@
 
 @()(implicit messages: Messages, user : User[_])
-<a class="link-back" href="@controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent))">@messages("base.back")</a>
+<a class="link-back" href='@controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix)'>@messages("base.back")</a>

--- a/app/views/returnFrequency/change_return_frequency_confirmation.scala.html
+++ b/app/views/returnFrequency/change_return_frequency_confirmation.scala.html
@@ -48,7 +48,7 @@
 
     <a  id="finish"
         onclick="sendGAEvent('return-frequency','finish','confirmation-vat-return-dates', @user.isAgent)"
-        href="@controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent))"
+        href='@controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix)'
         class="button"
         type="submit">@messages("common.finish")</a>
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,43 +1,45 @@
 # microservice specific routes
 
 # Assets
-GET         /assets/*file                                @controllers.Assets.at(path="/public", file)
+GET         /assets/*file                                    @controllers.Assets.at(path="/public", file)
 
 # Pages
-GET         /change-business-details                     @controllers.CustomerCircumstanceDetailsController.show(isAgent: Option[Boolean])
 
-GET         /change-business-address                     @controllers.BusinessAddressController.initialiseJourney
+GET         /change-business-details                         @controllers.CustomerCircumstanceDetailsController.redirect
+GET         /change-business-details/:userType               @controllers.CustomerCircumstanceDetailsController.show(userType: String)
 
-GET         /change-business-name                        @controllers.ChangeBusinessNameController.show
-GET         /change-business-name/coho-handoff           @controllers.ChangeBusinessNameController.handOffToCOHO
+GET         /change-business-address                         @controllers.BusinessAddressController.initialiseJourney
 
-GET         /change-business-address/callback            @controllers.BusinessAddressController.callback(id: String)
-GET         /change-business-address/confirmation        @controllers.BusinessAddressController.confirmation(isAgent: Boolean)
+GET         /change-business-name                            @controllers.ChangeBusinessNameController.show
+GET         /change-business-name/coho-handoff               @controllers.ChangeBusinessNameController.handOffToCOHO
 
-GET         /change-vat-return-dates                     @controllers.returnFrequency.ChooseDatesController.show
-POST        /change-vat-return-dates                     @controllers.returnFrequency.ChooseDatesController.submit
+GET         /change-business-address/callback                @controllers.BusinessAddressController.callback(id: String)
+GET         /change-business-address/confirmation/:userType  @controllers.BusinessAddressController.confirmation(userType: String)
 
-GET         /confirm-vat-return-dates                    @controllers.returnFrequency.ConfirmVatDatesController.show
-POST        /confirm-vat-return-dates                    @controllers.returnFrequency.ConfirmVatDatesController.submit
+GET         /change-vat-return-dates                         @controllers.returnFrequency.ChooseDatesController.show
+POST        /change-vat-return-dates                         @controllers.returnFrequency.ChooseDatesController.submit
 
-GET         /confirmation-vat-return-dates               @controllers.returnFrequency.ChangeReturnFrequencyConfirmation.show(isAgent: Boolean)
+GET         /confirm-vat-return-dates                        @controllers.returnFrequency.ConfirmVatDatesController.show
+POST        /confirm-vat-return-dates                        @controllers.returnFrequency.ConfirmVatDatesController.submit
 
-GET         /client-vat-number                           @controllers.agentClientRelationship.SelectClientVrnController.show
-POST        /client-vat-number                           @controllers.agentClientRelationship.SelectClientVrnController.submit
+GET         /confirmation-vat-return-dates/:userType         @controllers.returnFrequency.ChangeReturnFrequencyConfirmation.show(userType: String)
 
-GET         /unauthorised-for-client                     @controllers.agentClientRelationship.AgentUnauthorisedForClientController.show
+GET         /client-vat-number                               @controllers.agentClientRelationship.SelectClientVrnController.show
+POST        /client-vat-number                               @controllers.agentClientRelationship.SelectClientVrnController.submit
 
-GET         /change-client-vat-number                    @controllers.agentClientRelationship.ConfirmClientVrnController.changeClient
+GET         /unauthorised-for-client                         @controllers.agentClientRelationship.AgentUnauthorisedForClientController.show
 
-GET         /confirm-client-vat-number                   @controllers.agentClientRelationship.ConfirmClientVrnController.show
+GET         /change-client-vat-number                        @controllers.agentClientRelationship.ConfirmClientVrnController.changeClient
 
-GET         /initialise-payment-journey                  @controllers.PaymentsController.sendToPayments
+GET         /confirm-client-vat-number                       @controllers.agentClientRelationship.ConfirmClientVrnController.show
+
+GET         /initialise-payment-journey                      @controllers.PaymentsController.sendToPayments
 
 #Sign Out Routes
-GET         /sign-out                                    @controllers.SignOutController.signOut(authorised: Boolean)
-GET         /time-out                                    @controllers.SignOutController.timeout
+GET         /sign-out                                        @controllers.SignOutController.signOut(authorised: Boolean)
+GET         /time-out                                        @controllers.SignOutController.timeout
 
 #Feedback Routes
-GET         /feedback                                    @controllers.feedback.FeedbackController.show
-POST        /feedback                                    @controllers.feedback.FeedbackController.submit
-GET         /thankyou                                    @controllers.feedback.FeedbackController.thankyou
+GET         /feedback                                        @controllers.feedback.FeedbackController.show
+POST        /feedback                                        @controllers.feedback.FeedbackController.submit
+GET         /thankyou                                        @controllers.feedback.FeedbackController.thankyou

--- a/it/pages/BusinessAddressControllerISpec.scala
+++ b/it/pages/BusinessAddressControllerISpec.scala
@@ -129,7 +129,7 @@ class BusinessAddressControllerISpec extends BasePageISpec {
 
         res should have(
           httpStatus(SEE_OTHER),
-          redirectURI("/vat-through-software/account/change-business-address/confirmation?isAgent=false")
+          redirectURI("/vat-through-software/account/change-business-address/confirmation/non-agent")
         )
       }
     }
@@ -161,7 +161,7 @@ class BusinessAddressControllerISpec extends BasePageISpec {
 
         res should have(
           httpStatus(SEE_OTHER),
-          redirectURI("/vat-through-software/account/change-business-address/confirmation?isAgent=true")
+          redirectURI("/vat-through-software/account/change-business-address/confirmation/agent")
         )
       }
     }

--- a/it/pages/CustomerCircumstancesDetailsControllerISpec.scala
+++ b/it/pages/CustomerCircumstancesDetailsControllerISpec.scala
@@ -31,9 +31,9 @@ class CustomerCircumstancesDetailsControllerISpec extends BasePageISpec {
 
   "Calling the .show action" when {
 
-    def show(sessionVrn: Option[String] = None): WSResponse = get(path, formatSessionVrn(sessionVrn))
-
     "the user is an Agent" when {
+
+      def show(sessionVrn: Option[String] = None): WSResponse = get(path + "/agent", formatSessionVrn(sessionVrn))
 
       "the Agent is signed up for HMRC-AS-AGENT (authorised)" when {
 
@@ -279,6 +279,8 @@ class CustomerCircumstancesDetailsControllerISpec extends BasePageISpec {
 
     "the user is a Principle Entity and not an Agent" when {
 
+      def show(sessionVrn: Option[String] = None): WSResponse = get(s"$path/non-agent", formatSessionVrn(sessionVrn))
+
       "the Registration Status Feature is enabled" should {
 
         "Render the Customer Circumstances page with the Registration section visible" in {
@@ -477,6 +479,6 @@ class CustomerCircumstancesDetailsControllerISpec extends BasePageISpec {
 
     }
 
-    getAuthenticationTests(path)
+    getAuthenticationTests(s"$path/non-agent")
   }
 }

--- a/it/pages/agentClientRelationship/SelectClientVrnControllerISpec.scala
+++ b/it/pages/agentClientRelationship/SelectClientVrnControllerISpec.scala
@@ -86,7 +86,7 @@ class SelectClientVrnControllerISpec extends BasePageISpec {
 
         res should have(
           httpStatus(SEE_OTHER),
-          redirectURI(controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false)).url)
+          redirectURI(controllers.routes.CustomerCircumstanceDetailsController.show("non-agent").url)
         )
       }
     }
@@ -178,7 +178,7 @@ class SelectClientVrnControllerISpec extends BasePageISpec {
 
         res should have(
           httpStatus(SEE_OTHER),
-          redirectURI(controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false)).url)
+          redirectURI(controllers.routes.CustomerCircumstanceDetailsController.show("non-agent").url)
         )
       }
     }

--- a/it/pages/returnFrequency/ChangeReturnFrequencyConfirmationISpec.scala
+++ b/it/pages/returnFrequency/ChangeReturnFrequencyConfirmationISpec.scala
@@ -25,14 +25,14 @@ import play.api.test.Helpers._
 
 class ChangeReturnFrequencyConfirmationISpec extends BasePageISpec {
 
-  val path = "/confirmation-vat-return-dates?isAgent"
+  val path = "/confirmation-vat-return-dates"
   lazy val mockAppConfig: FrontendAppConfig = app.injector.instanceOf[FrontendAppConfig]
 
   "Calling .show" when {
 
-    def show(sessionVrn: Option[String] = None): WSResponse = get(s"$path=true", formatSessionVrn(sessionVrn))
-
     "the user is a Principle Entity and not an Agent" should {
+
+      def show(sessionVrn: Option[String] = None): WSResponse = get(s"$path/non-agent", formatSessionVrn(sessionVrn))
 
       "render the return frequency confirmation page" in {
 
@@ -50,6 +50,8 @@ class ChangeReturnFrequencyConfirmationISpec extends BasePageISpec {
 
     "the user is an Agent" when {
 
+      def show(sessionVrn: Option[String] = None): WSResponse = get(s"$path/agent", formatSessionVrn(sessionVrn))
+
       "a valid VRN is being stored" should {
 
         "render the return frequency confirmation page" in {
@@ -66,9 +68,6 @@ class ChangeReturnFrequencyConfirmationISpec extends BasePageISpec {
           )
         }
       }
-    }
-
-    "the user is an Agent" when {
 
       "no VRN is being stored" should {
 
@@ -86,9 +85,6 @@ class ChangeReturnFrequencyConfirmationISpec extends BasePageISpec {
           )
         }
       }
-    }
-
-    "the user is an Agent" when {
 
       "who is unauthorised" should {
 

--- a/it/pages/returnFrequency/ConfirmVatDatesControllerISpec.scala
+++ b/it/pages/returnFrequency/ConfirmVatDatesControllerISpec.scala
@@ -94,7 +94,7 @@ class ConfirmVatDatesControllerISpec extends BasePageISpec {
 
           res should have(
             httpStatus(SEE_OTHER),
-            redirectURI(controllers.returnFrequency.routes.ChangeReturnFrequencyConfirmation.show(false).url)
+            redirectURI(controllers.returnFrequency.routes.ChangeReturnFrequencyConfirmation.show("non-agent").url)
           )
         }
       }
@@ -136,7 +136,7 @@ class ConfirmVatDatesControllerISpec extends BasePageISpec {
 
           res should have(
             httpStatus(SEE_OTHER),
-            redirectURI(controllers.returnFrequency.routes.ChangeReturnFrequencyConfirmation.show(true).url)
+            redirectURI(controllers.returnFrequency.routes.ChangeReturnFrequencyConfirmation.show("agent").url)
           )
         }
       }

--- a/test/assets/PaymentsTestConstants.scala
+++ b/test/assets/PaymentsTestConstants.scala
@@ -25,16 +25,16 @@ object PaymentsTestConstants {
   val principlePaymentStart: PaymentStartModel = PaymentStartModel(
     vrn,
     isAgent = false,
-    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false)),
-    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false)),
-    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false))
+    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show("non-agent"),
+    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show("non-agent"),
+    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show("non-agent")
   )
 
   val agentPaymentStart: PaymentStartModel = PaymentStartModel(
     vrn,
     isAgent = true,
-    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(true)),
-    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(true)),
+    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show("agent"),
+    "/manage-vat-subscription-frontend" + controllers.routes.CustomerCircumstanceDetailsController.show("agent"),
     "/manage-vat-subscription-frontend" + controllers.agentClientRelationship.routes.SelectClientVrnController.show()
   )
 

--- a/test/controllers/BusinessAddressControllerSpec.scala
+++ b/test/controllers/BusinessAddressControllerSpec.scala
@@ -73,7 +73,7 @@ class BusinessAddressControllerSpec extends ControllerBaseSpec with MockAddressL
           }
 
           "Redirect to the confirmation page" in {
-            redirectLocation(result) shouldBe Some(controllers.routes.BusinessAddressController.confirmation(isAgent = false).url)
+            redirectLocation(result) shouldBe Some(controllers.routes.BusinessAddressController.confirmation("non-agent").url)
           }
         }
 
@@ -87,7 +87,7 @@ class BusinessAddressControllerSpec extends ControllerBaseSpec with MockAddressL
           }
 
           "Redirect to the confirmation page" in {
-            redirectLocation(result) shouldBe Some(controllers.routes.BusinessAddressController.confirmation(isAgent = true).url)
+            redirectLocation(result) shouldBe Some(controllers.routes.BusinessAddressController.confirmation("agent").url)
           }
         }
       }
@@ -182,7 +182,7 @@ class BusinessAddressControllerSpec extends ControllerBaseSpec with MockAddressL
       mockAuditingService,
       mockConfig)
 
-    lazy val result = controller.confirmation(false)(request)
+    lazy val result = controller.confirmation("non-agent")(request)
 
     "Return status 200 (OK)" in {
       status(result) shouldBe Status.OK

--- a/test/controllers/returnFrequency/ChangeReturnFrequencyConfirmationSpec.scala
+++ b/test/controllers/returnFrequency/ChangeReturnFrequencyConfirmationSpec.scala
@@ -38,7 +38,7 @@ class ChangeReturnFrequencyConfirmationSpec extends ControllerBaseSpec with Mock
 
     "the user is authorised" should {
 
-      lazy val result = TestChangeReturnFrequencyConfirmation.show(user.isAgent)(request)
+      lazy val result = TestChangeReturnFrequencyConfirmation.show(user.redirectSuffix)(request)
       lazy val document = Jsoup.parse(bodyOf(result))
 
       "return 200" in {
@@ -56,6 +56,6 @@ class ChangeReturnFrequencyConfirmationSpec extends ControllerBaseSpec with Mock
       }
     }
 
-    unauthenticatedCheck(TestChangeReturnFrequencyConfirmation.show(user.isAgent))
+    unauthenticatedCheck(TestChangeReturnFrequencyConfirmation.show(user.redirectSuffix))
   }
 }

--- a/test/controllers/returnFrequency/ConfirmVatDatesControllerSpec.scala
+++ b/test/controllers/returnFrequency/ConfirmVatDatesControllerSpec.scala
@@ -116,7 +116,7 @@ class ConfirmVatDatesControllerSpec extends ControllerBaseSpec
 
       "return a location to the received dates view" in {
         setupMockReturnFrequencyServiceWithSuccess()
-        val test = s"/vat-through-software/account/confirmation-vat-return-dates?isAgent=false"
+        val test = s"/vat-through-software/account/confirmation-vat-return-dates/non-agent"
         redirectLocation(result) shouldBe Some(test)
       }
     }
@@ -145,7 +145,7 @@ class ConfirmVatDatesControllerSpec extends ControllerBaseSpec
 
       "return a location to the received dates view" in {
         setupMockReturnFrequencyServiceWithSuccess()
-        val test = s"/vat-through-software/account/confirmation-vat-return-dates?isAgent=true"
+        val test = s"/vat-through-software/account/confirmation-vat-return-dates/agent"
         redirectLocation(result) shouldBe Some(test)
       }
     }

--- a/test/views/agentClientRelationship/ConfirmClientVrnViewSpec.scala
+++ b/test/views/agentClientRelationship/ConfirmClientVrnViewSpec.scala
@@ -55,8 +55,8 @@ class ConfirmClientVrnViewSpec extends ViewBaseSpec {
           elementText("a.button") shouldBe BaseMessages.confirmAndContinue
         }
 
-        s"has a link to '${controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(true)).url}'" in {
-          element("a.button").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(true)).url
+        s"""has a link to '${controllers.routes.CustomerCircumstanceDetailsController.show("agent").url}'""" in {
+          element("a.button").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show("agent").url
         }
       }
 

--- a/test/views/businessAddress/ChangeAddressConfirmationViewSpec.scala
+++ b/test/views/businessAddress/ChangeAddressConfirmationViewSpec.scala
@@ -57,8 +57,8 @@ class ChangeAddressConfirmationViewSpec extends ViewBaseSpec {
         elementText("#finish") shouldBe BaseMessages.finish
       }
 
-      s"has the correct link to '${controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false)).url}'" in {
-        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false)).url
+      s"has the correct link to '${controllers.routes.CustomerCircumstanceDetailsController.show("non-agent").url}'" in {
+        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show("non-agent").url
       }
     }
   }
@@ -96,8 +96,8 @@ class ChangeAddressConfirmationViewSpec extends ViewBaseSpec {
         elementText("#finish") shouldBe BaseMessages.finish
       }
 
-      s"has the correct link to '${controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(true)).url}'" in {
-        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(true)).url
+      s"has the correct link to '${controllers.routes.CustomerCircumstanceDetailsController.show("agent").url}'" in {
+        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show("agent").url
       }
     }
   }

--- a/test/views/businessName/ChangeBusinessNameViewSpec.scala
+++ b/test/views/businessName/ChangeBusinessNameViewSpec.scala
@@ -48,7 +48,7 @@ class ChangeBusinessNameViewSpec extends ViewBaseSpec {
 
     s"have a the back link with correct text and url '${BaseMessages.back}'" in {
       elementText(Selectors.backLink) shouldBe BaseMessages.back
-      element(Selectors.backLink).attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent)).url
+      element(Selectors.backLink).attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix).url
     }
 
     s"have a the correct page heading of '${viewMessages.h1}'" in {

--- a/test/views/returnFrequency/ChangeReturnFrequencyConfirmationViewSpec.scala
+++ b/test/views/returnFrequency/ChangeReturnFrequencyConfirmationViewSpec.scala
@@ -67,7 +67,7 @@ class ChangeReturnFrequencyConfirmationViewSpec extends ViewBaseSpec {
       }
 
       s"has link back to customer details page" in {
-        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(false)).url
+        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show("non-agent").url
       }
     }
   }
@@ -118,7 +118,7 @@ class ChangeReturnFrequencyConfirmationViewSpec extends ViewBaseSpec {
       }
 
       s"has link back to customer details page" in {
-        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(isAgent = Some(true)).url
+        element("#finish").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show("agent").url
       }
     }
   }

--- a/test/views/returnFrequency/ChooseDatesViewSpec.scala
+++ b/test/views/returnFrequency/ChooseDatesViewSpec.scala
@@ -62,7 +62,7 @@ class ChooseDatesViewSpec extends ViewBaseSpec {
     }
     s"have a the back link with correct text and url '${BaseMessages.back}'" in {
       elementText(".link-back") shouldBe BaseMessages.back
-      element(".link-back").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(Some(user.isAgent)).url
+      element(".link-back").attr("href") shouldBe controllers.routes.CustomerCircumstanceDetailsController.show(user.redirectSuffix).url
     }
   }
 


### PR DESCRIPTION
Note, this is a little clumsy - but it has been requested by the Digital Analytics team.

Associated Acceptance Test PR:
https://github.com/hmrc/change-vat-acceptance-tests/pull/61