### PR TITLE
[auth-corrections] Auth redirect to ggSignIn instead of session timeout

### DIFF
--- a/app/controllers/SignOutController.scala
+++ b/app/controllers/SignOutController.scala
@@ -35,6 +35,6 @@ class SignOutController @Inject()(val messagesApi: MessagesApi,
   }
 
   val timeout: Action[AnyContent] = Action.async { implicit request =>
-     Future.successful(Redirect(appConfig.unauthorisedSignOutUrl))
+     Future.successful(Unauthorized(views.html.errors.sessionTimeout()))
   }
 }

--- a/app/controllers/predicates/AuthPredicate.scala
+++ b/app/controllers/predicates/AuthPredicate.scala
@@ -58,8 +58,8 @@ class AuthPredicate @Inject()(enrolmentsAuthService: EnrolmentsAuthService,
         Future.successful(serviceErrorHandler.showInternalServerError)
     } recover {
       case _: NoActiveSession =>
-        Logger.debug("[AuthPredicate][invokeBlock] - No active session, rendering Session Timeout view")
-        Unauthorized(views.html.errors.sessionTimeout())
+        Logger.debug("[AuthPredicate][invokeBlock] - No active session, redirect to GG sign in")
+        Redirect(appConfig.signInUrl)
       case _: AuthorisationException =>
         Logger.warn("[AuthPredicate][invokeBlock] - Unauthorised exception, rendering Unauthorised view")
         Forbidden(views.html.errors.unauthorised())

--- a/app/controllers/predicates/AuthoriseAsAgentOnly.scala
+++ b/app/controllers/predicates/AuthoriseAsAgentOnly.scala
@@ -59,8 +59,8 @@ class AuthoriseAsAgentOnly @Inject()(enrolmentsAuthService: EnrolmentsAuthServic
           Future.successful(serviceErrorHandler.showInternalServerError)
       } recover {
         case _: NoActiveSession =>
-          Logger.debug("[AuthoriseAsAgentOnly][invokeBlock] - No Active Session, rendering Session Timeout view")
-          Unauthorized(views.html.errors.sessionTimeout())
+          Logger.debug("[AuthoriseAsAgentOnly][invokeBlock] - No Active Session, redirect to GG Sign In")
+          Redirect(appConfig.signInUrl)
         case _: AuthorisationException =>
           Logger.warn("[AuthoriseAsAgentOnly][invokeBlock] - Authorisation Exception, rendering Unauthorised view")
           Forbidden(views.html.errors.unauthorised())

--- a/app/controllers/predicates/AuthoriseAsAgentWithClient.scala
+++ b/app/controllers/predicates/AuthoriseAsAgentWithClient.scala
@@ -65,8 +65,8 @@ class AuthoriseAsAgentWithClient @Inject()(enrolmentsAuthService: EnrolmentsAuth
               block(user)
           } recover {
             case _: NoActiveSession =>
-              Logger.debug(s"[AuthoriseAsAgentWithClient][invokeBlock] - Agent does not have an active session, rendering Session Timeout")
-              Unauthorized(views.html.errors.sessionTimeout())
+              Logger.debug(s"[AuthoriseAsAgentWithClient][invokeBlock] - Agent does not have an active session, redirect to GG Sign In")
+              Redirect(appConfig.signInUrl)
             case _: AuthorisationException =>
               Logger.warn(s"[AuthoriseAsAgentWithClient][invokeBlock] - Agent does not have delegated authority for Client")
               Redirect(controllers.agentClientRelationship.routes.AgentUnauthorisedForClientController.show())

--- a/it/pages/BasePageISpec.scala
+++ b/it/pages/BasePageISpec.scala
@@ -20,7 +20,7 @@ import common.SessionKeys
 import helpers.BaseIntegrationSpec
 import play.api.i18n.Messages
 import play.api.libs.ws.WSResponse
-import play.api.test.Helpers.{INTERNAL_SERVER_ERROR, UNAUTHORIZED}
+import play.api.test.Helpers.{INTERNAL_SERVER_ERROR, SEE_OTHER}
 
 trait BasePageISpec extends BaseIntegrationSpec {
 
@@ -36,7 +36,7 @@ trait BasePageISpec extends BaseIntegrationSpec {
 
     "the user is timed out (not authenticated)" should {
 
-      "Render the session timeout view" in {
+      "redirect to GG Sign In" in {
 
         given.user.isNotAuthenticated
 
@@ -44,8 +44,8 @@ trait BasePageISpec extends BaseIntegrationSpec {
         val res = method
 
         res should have(
-          httpStatus(UNAUTHORIZED),
-          pageTitle(Messages("sessionTimeout.title"))
+          httpStatus(SEE_OTHER),
+          redirectURI(appConfig.signInUrl)
         )
       }
     }

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -29,7 +29,7 @@ trait ControllerBaseSpec extends MockAuth {
       "return 401 (Unauthorised)" in {
         mockMissingBearerToken()
         val result = controllerAction(request)
-        status(result) shouldBe Status.UNAUTHORIZED
+        status(result) shouldBe Status.SEE_OTHER
       }
     }
   }

--- a/test/controllers/SignOutControllerSpec.scala
+++ b/test/controllers/SignOutControllerSpec.scala
@@ -47,12 +47,12 @@ class SignOutControllerSpec extends ControllerBaseSpec {
     }
   }
 
-  "signing out on timeout" should {
-    "return 303 and navigate to the expected sign out url" in {
+  "navigating to sign-out" should {
+
+    "return 401 unauthorised and render session timeout view" in {
       lazy val result: Future[Result] = TestSignOutController.timeout(request)
 
-      status(result) shouldBe SEE_OTHER
-      redirectLocation(result) shouldBe Some(mockConfig.unauthorisedSignOutUrl)
+      status(result) shouldBe UNAUTHORIZED
     }
   }
 }

--- a/test/controllers/agentClientRelationship/ConfirmClientVrnControllerSpec.scala
+++ b/test/controllers/agentClientRelationship/ConfirmClientVrnControllerSpec.scala
@@ -116,7 +116,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockAuth wi
       "return 401 (Unauthorised)" in {
         mockMissingBearerToken()
         val result = TestConfirmClientVrnControllerSpec.show(fakeRequestWithClientsVRN)
-        status(result) shouldBe Status.UNAUTHORIZED
+        status(result) shouldBe Status.SEE_OTHER
       }
     }
   }
@@ -161,7 +161,7 @@ class ConfirmClientVrnControllerSpec extends ControllerBaseSpec with MockAuth wi
       "return 401 (Unauthorised)" in {
         mockMissingBearerToken()
         val result = TestConfirmClientVrnControllerSpec.changeClient(fakeRequestWithClientsVRN)
-        status(result) shouldBe Status.UNAUTHORIZED
+        status(result) shouldBe Status.SEE_OTHER
       }
     }
   }

--- a/test/controllers/predicates/AuthoriseAsAgentOnlySpec.scala
+++ b/test/controllers/predicates/AuthoriseAsAgentOnlySpec.scala
@@ -25,6 +25,7 @@ import play.api.mvc.Results.Ok
 import play.api.mvc.{Action, AnyContent}
 
 import scala.concurrent.Future
+import play.api.test.Helpers._
 
 class AuthoriseAsAgentOnlySpec extends MockAuth with ControllerBaseSpec {
 
@@ -85,10 +86,15 @@ class AuthoriseAsAgentOnlySpec extends MockAuth with ControllerBaseSpec {
 
       "a user with no active session" should {
 
-        "return 401 (Unauthorized)" in {
+        lazy val result = target(request)
+
+        "return 303 (Redirect)" in {
           mockMissingBearerToken()
-          val result = target(request)
-          status(result) shouldBe Status.UNAUTHORIZED
+          status(result) shouldBe Status.SEE_OTHER
+        }
+
+        "redirect to the session-timout view" in {
+          redirectLocation(result) shouldBe Some(mockConfig.signInUrl)
         }
       }
 

--- a/test/controllers/predicates/AuthoriseAsAgentWithClientSpec.scala
+++ b/test/controllers/predicates/AuthoriseAsAgentWithClientSpec.scala
@@ -63,10 +63,15 @@ class AuthoriseAsAgentWithClientSpec extends MockAuth {
 
       "the agent is not authenticated" should {
 
-        "return 401 (Unauthorised)" in {
+        lazy val result = target(fakeRequestWithClientsVRN)
+
+        "return 303 (Redirect)" in {
           mockMissingBearerToken()
-          val result = target(fakeRequestWithClientsVRN)
-          status(result) shouldBe Status.UNAUTHORIZED
+          status(result) shouldBe Status.SEE_OTHER
+        }
+
+        "redirect to the session-timout view" in {
+          redirectLocation(result) shouldBe Some(mockConfig.signInUrl)
         }
       }
 


### PR DESCRIPTION
Currently, if you arrive at the service and are not signed in it assumed session timeout. This leads to some unexpected behaviour for agents when they access the service directly from GovUK.

This change redirects users to GG Sign In.

Redirection to the timeout is only performed by the session timeout dialogue now.