### PR TITLE
Removed declaration from ALF handoff and VAT return dates confirm pages

### DIFF
--- a/app/models/customerAddress/AddressLookupJsonBuilder.scala
+++ b/app/models/customerAddress/AddressLookupJsonBuilder.scala
@@ -51,8 +51,7 @@ case class AddressLookupJsonBuilder(continueUrl: String)(implicit user: User[_],
   val confirmPage = Json.obj(
     "title" -> messages("address_lookupPage.confirmPage.heading"),
     "heading" -> messages("address_lookupPage.confirmPage.heading"),
-    "showConfirmChangeText" -> true,
-    "confirmChangeText" ->  messages("address_lookupPage.confirmPage.confirmChangeText")
+    "showConfirmChangeText" -> false
   )
 }
 

--- a/app/testOnly/models/StubAddressLookupJourneyConfig.scala
+++ b/app/testOnly/models/StubAddressLookupJourneyConfig.scala
@@ -40,8 +40,7 @@ case class SelectPage(title: Option[String] = None,
 
 case class ConfirmPage(title: Option[String] = None,
                        heading: Option[String] = None,
-                       showConfirmChangeText: Option[Boolean] = Some(false),
-                       confirmChangeText: Option[String] = None)
+                       showConfirmChangeText: Option[Boolean] = Some(false))
 
 object StubAddressLookupJourneyConfig {
 

--- a/app/testOnly/views/stubAddressLookup.scala.html
+++ b/app/testOnly/views/stubAddressLookup.scala.html
@@ -62,7 +62,6 @@
                 @row("title",confirmPage.title.get)
                 @row("heading",confirmPage.heading.get)
                 @row("showConfirmChangeText",confirmPage.showConfirmChangeText.get.toString)
-                @row("confirmChangeText",confirmPage.confirmChangeText.get)
             }
         </dl>
 

--- a/app/views/returnFrequency/confirm_dates.scala.html
+++ b/app/views/returnFrequency/confirm_dates.scala.html
@@ -46,8 +46,6 @@
       </a>
   </p>
 
-  <p id="p2">@messages("confirm_return_frequency.p2")</p>
-
   @form(action = controllers.returnFrequency.routes.ConfirmVatDatesController.submit()) {
     <button
             class="button"

--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,7 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 val compile: Seq[ModuleID] = Seq(
   ws,
   "uk.gov.hmrc" %% "bootstrap-play-25" % "4.11.0",
-  "uk.gov.hmrc" %% "play-partials" % "6.8.0-play-25",
+  "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-25",
   "uk.gov.hmrc" %% "play-whitelist-filter" % "2.0.0",
   "uk.gov.hmrc" %% "govuk-template" % "5.28.0-play-25",
   "uk.gov.hmrc" %% "play-ui" % "7.39.0-play-25",

--- a/conf/messages
+++ b/conf/messages
@@ -158,7 +158,6 @@ confirm_return_frequency.title = Confirm the new VAT Return dates
 confirm_return_frequency.heading = Confirm the new VAT Return dates
 confirm_return_frequency.newDates = The new VAT Return dates are
 confirm_return_frequency.changeLink = Change the VAT Return dates
-confirm_return_frequency.p2 = By confirming this change, you agree that the information you have given is complete and correct.
 
 received_frequency.title = We have received the new VAT Return dates
 received_frequency.heading = We have received the new VAT Return dates
@@ -184,7 +183,6 @@ address_lookupPage.postcode.link = The address does not have a post code
 address_lookupPage.selectPage.heading = Select the new address
 address_lookupPage.selectPage.editLink = Edit the address manually
 address_lookupPage.confirmPage.heading = Confirm the new principal place of business
-address_lookupPage.confirmPage.confirmChangeText = By confirming this change, you agree that the information you have given is complete and correct.
 
 breadcrumb.bta = Business tax account
 breadcrumb.yourVatDetails = Your VAT details

--- a/test/assets/CustomerAddressTestConstants.scala
+++ b/test/assets/CustomerAddressTestConstants.scala
@@ -133,8 +133,7 @@ object CustomerAddressTestConstants {
     "confirmPage" -> Json.obj(
       "title" -> AddressLookupMessages.confirmHeading,
       "heading" -> AddressLookupMessages.confirmHeading,
-      "showConfirmChangeText" -> true,
-      "confirmChangeText" -> AddressLookupMessages.confirmChangeText
+      "showConfirmChangeText" -> false
     )
   )
 
@@ -161,8 +160,7 @@ object CustomerAddressTestConstants {
     "confirmPage" -> Json.obj(
       "title" -> AddressLookupMessages.confirmHeading,
       "heading" -> AddressLookupMessages.confirmHeading,
-      "showConfirmChangeText" -> true,
-      "confirmChangeText" -> AddressLookupMessages.confirmChangeText
+      "showConfirmChangeText" -> false
     )
   )
 

--- a/test/views/returnFrequency/ConfirmDatesViewSpec.scala
+++ b/test/views/returnFrequency/ConfirmDatesViewSpec.scala
@@ -80,10 +80,6 @@ class ConfirmDatesViewSpec extends ViewBaseSpec {
 
     }
 
-    s"have a the correct p2 of '${viewMessages.ConfirmPage.p2}'" in {
-      elementText("#p2") shouldBe viewMessages.ConfirmPage.p2
-    }
-
     "have a confirm button" which {
 
       s"has the text '${BaseMessages.confirmAndContinue}'" in {


### PR DESCRIPTION
To test ALF handoff displays correctly - turn 'Stub Address Lookup' feature switch off