### PR TITLE
Added useVatReturnPeriodFrontend feature switch

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -97,4 +97,7 @@ object ConfigKeys {
 
   val accessibilityReportHost: String = "accessibilityReport.host"
   val accessibilityReportUrl: String = "accessibilityReport.url"
+
+  val vatReturnPeriodFrontendHost: String = "vat-return-period-frontend.host"
+  val vatReturnPeriodFrontendUrl: String = "vat-return-period-frontend.url"
 }

--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -51,6 +51,7 @@ object ConfigKeys {
   val changeClientFeature: String = "features.changeClientFeature.enabled"
   val useNewAddressLookupFeature: String = "features.useNewAddressLookupFeature.enabled"
   val accessibilityReportFeature: String = "features.accessibilityReport.enabled"
+  val useVatReturnPeriodFrontend: String = "features.useVatReturnPeriodFrontend.enabled"
 
   // GOV UK
   val changeVatRegistrationDetails: String = "gov-uk.guidance.changeVatRegistrationDetails.url"

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -79,9 +79,10 @@ trait AppConfig extends ServicesConfig {
   val contactPreferencesService: String
   def contactPreferencesUrl(vrn: String): String
   val vatOptOutUrl: String
-  def languageMap:Map[String,Lang]
-  val routeToSwitchLanguage :String => Call
-  val accessibilityReportUrl : String
+  def languageMap: Map[String,Lang]
+  val routeToSwitchLanguage: String => Call
+  val accessibilityReportUrl: String
+  val vatReturnPeriodFrontendUrl: String
 }
 
 @Singleton
@@ -232,7 +233,9 @@ class FrontendAppConfig @Inject()(environment: Environment, implicit val runMode
 
   override val routeToSwitchLanguage: String => Call = (lang: String) => controllers.routes.LanguageController.switchToLanguage(lang)
 
-  private lazy val accessibilityReportHost : String = getString(Keys.accessibilityReportHost)
-  override lazy val accessibilityReportUrl : String = accessibilityReportHost + getString(Keys.accessibilityReportUrl)
+  private lazy val accessibilityReportHost: String = getString(Keys.accessibilityReportHost)
+  override lazy val accessibilityReportUrl: String = accessibilityReportHost + getString(Keys.accessibilityReportUrl)
 
+  private lazy val vatReturnPeriodFrontendHost: String = getString(ConfigKeys.vatReturnPeriodFrontendHost)
+  override lazy val vatReturnPeriodFrontendUrl: String = vatReturnPeriodFrontendHost + getString(ConfigKeys.vatReturnPeriodFrontendUrl)
 }

--- a/app/config/features/Features.scala
+++ b/app/config/features/Features.scala
@@ -39,4 +39,5 @@ class Features @Inject()(implicit config: Configuration) {
   val changeClientFeature = new Feature(ConfigKeys.changeClientFeature)
   val useNewAddressLookupFeature = new Feature(ConfigKeys.useNewAddressLookupFeature)
   val accessibilityReportFeature = new Feature(ConfigKeys.accessibilityReportFeature)
+  val useVatReturnPeriodFrontend = new Feature(ConfigKeys.useVatReturnPeriodFrontend)
 }

--- a/app/testOnly/controllers/FeatureSwitchController.scala
+++ b/app/testOnly/controllers/FeatureSwitchController.scala
@@ -56,7 +56,8 @@ class FeatureSwitchController @Inject()( vatSubscriptionFeaturesConnector: VatSu
             useOverseasIndicatorEnabled = appConfig.features.useOverseasIndicator(),
             changeClientFeature = appConfig.features.changeClientFeature(),
             useNewAddressLookupFeature = appConfig.features.useNewAddressLookupFeature(),
-            accessibilityReportFeature = appConfig.features.accessibilityReportFeature()
+            accessibilityReportFeature = appConfig.features.accessibilityReportFeature(),
+            useVatReturnPeriodFrontend = appConfig.features.useVatReturnPeriodFrontend()
           )
         )
         Logger.debug(s"[FeatureSwitchController][featureSwitch] form: $form")
@@ -87,6 +88,7 @@ class FeatureSwitchController @Inject()( vatSubscriptionFeaturesConnector: VatSu
     appConfig.features.changeClientFeature(model.changeClientFeature)
     appConfig.features.useNewAddressLookupFeature(model.useNewAddressLookupFeature)
     appConfig.features.accessibilityReportFeature(model.accessibilityReportFeature)
+    appConfig.features.useVatReturnPeriodFrontend(model.useVatReturnPeriodFrontend)
     vatSubscriptionFeaturesConnector.postFeatures(model.vatSubscriptionFeatures).map {
       response =>
         response.status match {

--- a/app/testOnly/forms/FeatureSwitchForm.scala
+++ b/app/testOnly/forms/FeatureSwitchForm.scala
@@ -49,7 +49,8 @@ object FeatureSwitchForm {
       ConfigKeys.useOverseasIndicator -> boolean,
       ConfigKeys.changeClientFeature -> boolean,
       ConfigKeys.useNewAddressLookupFeature -> boolean,
-      ConfigKeys.accessibilityReportFeature -> boolean
+      ConfigKeys.accessibilityReportFeature -> boolean,
+      ConfigKeys.useVatReturnPeriodFrontend -> boolean
     )(FeatureSwitchModel.apply)(FeatureSwitchModel.unapply)
   )
 }

--- a/app/testOnly/models/FeatureSwitchModel.scala
+++ b/app/testOnly/models/FeatureSwitchModel.scala
@@ -32,5 +32,6 @@ case class FeatureSwitchModel(
                                useOverseasIndicatorEnabled: Boolean,
                                changeClientFeature: Boolean,
                                useNewAddressLookupFeature: Boolean,
-                               accessibilityReportFeature : Boolean
+                               accessibilityReportFeature: Boolean,
+                               useVatReturnPeriodFrontend: Boolean
                              )

--- a/app/testOnly/views/featureSwitch.scala.html
+++ b/app/testOnly/views/featureSwitch.scala.html
@@ -46,6 +46,7 @@
               @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.useOverseasIndicator), messages(ConfigKeys.useOverseasIndicator))
               @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.changeClientFeature), messages(ConfigKeys.changeClientFeature))
               @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.useNewAddressLookupFeature), "use address lookup v2")
+              @views.html.templates.inputs.singleCheckbox(form(ConfigKeys.useVatReturnPeriodFrontend), "Use vat-return-period-frontend microservice")
           </fieldset>
       </div>
 

--- a/app/views/customerInfo/customer_circumstance_details.scala.html
+++ b/app/views/customerInfo/customer_circumstance_details.scala.html
@@ -149,10 +149,11 @@
                         </span>
                     } else {
                         <a id="vat-return-dates-status"
-                           onclick="sendGAEvent('return-frequency','change','change-business-details', @user.isAgent)"
-                           href="@controllers.returnFrequency.routes.ChooseDatesController.show()"
-                           aria-label="@messages("customer_details.returnFrequency.change.hidden",render_return_frequency(period))">
-                        @messages("customer_details.change")
+                            onclick="sendGAEvent('return-frequency','change','change-business-details', @user.isAgent)"
+                            href="@{if(appConfig.features.useVatReturnPeriodFrontend()) appConfig.vatReturnPeriodFrontendUrl
+                                   else controllers.returnFrequency.routes.ChooseDatesController.show()}"
+                            aria-label="@messages("customer_details.returnFrequency.change.hidden",render_return_frequency(period))">
+                            @messages("customer_details.change")
                         </a>
                     }
                 }

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ val compile: Seq[ModuleID] = Seq(
   "uk.gov.hmrc" %% "bootstrap-play-25" % "5.0.0",
   "uk.gov.hmrc" %% "play-partials" % "6.9.0-play-25",
   "uk.gov.hmrc" %% "play-whitelist-filter" % "3.1.0-play-25",
-  "uk.gov.hmrc" %% "govuk-template" % "5.39.0-play-25",
+  "uk.gov.hmrc" %% "govuk-template" % "5.40.0-play-25",
   "uk.gov.hmrc" %% "play-ui" % "8.0.0-play-25",
   "org.typelevel" %% "cats" % "0.9.0",
   "uk.gov.hmrc" %% "play-language" % "3.4.0"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -122,6 +122,7 @@ features {
   changeClientFeature.enabled = true
   useNewAddressLookupFeature.enabled = true
   accessibilityReport.enabled = true
+  useVatReturnPeriodFrontend.enabled = false
 }
 
 accessibilityReport {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -225,6 +225,11 @@ vat-opt-out-frontend {
   url = "http://localhost:9166/vat-through-software/account/opt-out"
 }
 
+vat-return-period-frontend {
+  host = "http://localhost:9167"
+  url = "/vat-through-software/account/returns/change-vat-return-dates"
+}
+
 whitelist {
   allowedIps = "MTI3LjAuMC4x"
   excludedPaths = "L2hlYWx0aGNoZWNrLC9waW5nL3Bpbmc="

--- a/test/assets/CircumstanceDetailsTestConstants.scala
+++ b/test/assets/CircumstanceDetailsTestConstants.scala
@@ -230,6 +230,19 @@ object CircumstanceDetailsTestConstants {
     ppob = ppobModelMax,
     bankDetails = Some(bankDetailsModelMax),
     returnPeriod = Some(Mar),
+    deregistration = None,
+    changeIndicators = None,
+    pendingChanges = None,
+    partyType = Some(partyType)
+  )
+
+  val customerInformationNoPendingIndividualDeregistered: CircumstanceDetails = CircumstanceDetails(
+    mandationStatus = MTDfBMandated,
+    customerDetails = individual,
+    flatRateScheme = Some(frsModelMax),
+    ppob = ppobModelMax,
+    bankDetails = Some(bankDetailsModelMax),
+    returnPeriod = Some(Mar),
     deregistration = Some(deregModel),
     changeIndicators = None,
     pendingChanges = None,

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -88,4 +88,5 @@ class MockAppConfig(implicit val runModeConfiguration: Configuration) extends Ap
   override val agentClientLookupAgentAction: String = "/agent-action"
 
   override val accessibilityReportUrl : String = "/vat-through-software/accessibility-statement"
+  override val vatReturnPeriodFrontendUrl: String = "vat-return-period-url"
 }

--- a/test/utils/TestUtil.scala
+++ b/test/utils/TestUtil.scala
@@ -43,7 +43,26 @@ trait TestUtil extends UnitSpec with GuiceOneAppPerSuite with BeforeAndAfterEach
     mockConfig.features.simpleAuth(false)
     mockConfig.features.agentAccess(true)
     mockConfig.features.useNewAddressLookupFeature(false)
+    mockConfig.features.registrationStatus(true)
+    mockConfig.features.contactDetailsSection(true)
+    mockConfig.features.showContactNumbersAndWebsite(true)
+    mockConfig.features.allowAgentBankAccountChange(false)
+    mockConfig.features.useLanguageSelector(true)
+    mockConfig.features.useVatReturnPeriodFrontend(false)
     SharedMetricRegistries.clear()
+  }
+
+  override def afterEach(): Unit = {
+    super.beforeEach()
+    mockConfig.features.simpleAuth(false)
+    mockConfig.features.agentAccess(true)
+    mockConfig.features.useNewAddressLookupFeature(false)
+    mockConfig.features.registrationStatus(true)
+    mockConfig.features.contactDetailsSection(true)
+    mockConfig.features.showContactNumbersAndWebsite(true)
+    mockConfig.features.allowAgentBankAccountChange(false)
+    mockConfig.features.useLanguageSelector(true)
+    mockConfig.features.useVatReturnPeriodFrontend(false)
   }
 
   lazy val injector: Injector = app.injector

--- a/test/views/customerInfo/CustomerCircumstanceDetailsViewSpec.scala
+++ b/test/views/customerInfo/CustomerCircumstanceDetailsViewSpec.scala
@@ -32,282 +32,348 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
 
   "Rendering the Customer Details page" when {
 
-    "Viewing for an Individual without any pending changes" when {
+    "an Individual" when {
 
-      "registered for VAT" when {
+      "with full information" when {
 
-        "useVatReturnPeriodFrontend feature switch is off" should {
+        "with no pending changes" when {
 
-          lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
-          lazy implicit val document: Document = Jsoup.parse(view.body)
+          "registered for VAT" when {
 
-          s"have the correct document title '${viewMessages.title}'" in {
-            document.title shouldBe viewMessages.title
-          }
+            "useVatReturnPeriodFrontend feature switch is off" should {
 
-          "have the correct service name" in {
-            elementText(".header__menu__proposition-name") shouldBe clientServiceName
-          }
+              lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
+              lazy implicit val document: Document = Jsoup.parse(view.body)
 
-          s"have a the correct page heading '${viewMessages.heading}'" in {
-            elementText("h1") shouldBe viewMessages.heading
-          }
-
-          "display a breadcrumb trail which" in {
-            elementText(".breadcrumbs li:nth-of-type(1)") shouldBe breadcrumbBta
-            elementText(".breadcrumbs li:nth-of-type(2)") shouldBe breadcrumbVat
-            elementText(".breadcrumbs li:nth-of-type(3)") shouldBe breadcrumbBizDeets
-
-            element("#breadcrumb-bta").attr("href") shouldBe "ye olde bta url"
-            element("#breadcrumb-vat").attr("href") shouldBe "ye olde vat summary url"
-          }
-
-          "have a section for registration status" which {
-
-            "has a registration header" in {
-              elementText("#registration-section > h2") shouldBe viewMessages.registrationStatusHeading
-            }
-
-            "has a registration status header" in {
-              elementText("#registration-status-text") shouldBe viewMessages.statusText
-            }
-
-            "displays the correct registration status" in {
-              elementText("#registration-status") shouldBe viewMessages.registeredStatus
-            }
-          }
-
-          "has an about header" in {
-            elementText("#content > article > div:nth-child(2) > h2") shouldBe viewMessages.aboutHeading
-          }
-
-          "have a section for business address" which {
-
-            "has the heading" in {
-              elementText("#businessAddressHeading") shouldBe viewMessages.businessAddressHeading
-            }
-
-            "has the correct address output" in {
-              elementText("#businessAddress li:nth-child(1)") shouldBe customerInformationModelMaxIndividual.ppob.address.line1
-              elementText("#businessAddress li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.ppob.address.line2.get
-              elementText("#businessAddress li:nth-child(3)") shouldBe customerInformationModelMaxIndividual.ppob.address.postCode.get
-            }
-
-            "has a change link" which {
-
-              s"has the wording '${viewMessages.change}'" in {
-                elementText("#place-of-business-status") shouldBe viewMessages.change
+              s"have the correct document title '${viewMessages.title}'" in {
+                document.title shouldBe viewMessages.title
               }
 
-              s"has the correct aria label text '${viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)}'" in {
-                element("#place-of-business-status").attr("aria-label") shouldBe viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)
+              "have the correct service name" in {
+                elementText(".header__menu__proposition-name") shouldBe clientServiceName
               }
 
-              s"has a link to ${controllers.routes.BusinessAddressController.show().url}" in {
-                element("#place-of-business-status").attr("href") shouldBe controllers.routes.BusinessAddressController.show().url
-              }
-            }
-          }
-
-          "have a section for repayment Bank Account details" which {
-
-            "has the heading" in {
-              elementText("#bank-details-text") shouldBe viewMessages.bankDetailsHeading
-            }
-
-            "has a the correct Account Number" which {
-
-              "has the correct heading for the Account Number" in {
-                elementText("#bank-details li:nth-child(1)") shouldBe viewMessages.accountNumberHeading
+              s"have a the correct page heading '${viewMessages.heading}'" in {
+                elementText("h1") shouldBe viewMessages.heading
               }
 
-              "has the correct value for the account number" in {
-                elementText("#bank-details li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.bankAccountNumber.get
-              }
-            }
+              "display a breadcrumb trail which" in {
+                elementText(".breadcrumbs li:nth-of-type(1)") shouldBe breadcrumbBta
+                elementText(".breadcrumbs li:nth-of-type(2)") shouldBe breadcrumbVat
+                elementText(".breadcrumbs li:nth-of-type(3)") shouldBe breadcrumbBizDeets
 
-            "has a the correct Sort Code" which {
-
-              "has the correct heading for the Sort Code" in {
-                elementText("#bank-details li:nth-child(3)") shouldBe viewMessages.sortcodeHeading
+                element("#breadcrumb-bta").attr("href") shouldBe "ye olde bta url"
+                element("#breadcrumb-vat").attr("href") shouldBe "ye olde vat summary url"
               }
 
-              "has the correct value for the account number" in {
-                elementText("#bank-details li:nth-child(4)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.sortCode.get
-              }
-            }
+              "have a section for registration status" which {
 
-            "has a change link" which {
-
-              s"has the wording '${viewMessages.change}'" in {
-                elementText("#bank-details-status") shouldBe viewMessages.change
-              }
-
-              s"has the correct aria label text '${viewMessages.changeBankDetailsHidden}'" in {
-                element("#bank-details-status").attr("aria-label") shouldBe viewMessages.changeBankDetailsHidden
-              }
-
-              s"has a link to ${controllers.routes.PaymentsController.sendToPayments().url}" in {
-                element("#bank-details-status").attr("href") shouldBe controllers.routes.PaymentsController.sendToPayments().url
-              }
-            }
-          }
-
-          "have a section for return frequency" which {
-
-            "has the correct heading" in {
-              elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
-            }
-
-            "has the correct current frequency" in {
-              elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
-            }
-
-            "has a change link" which {
-
-              s"has the wording '${viewMessages.change}'" in {
-                elementText("#vat-return-dates-status") shouldBe viewMessages.change
-              }
-
-              s"has a link to ${controllers.returnFrequency.routes.ChooseDatesController.show().url}" in {
-                element("#vat-return-dates-status").attr("href") shouldBe controllers.returnFrequency.routes.ChooseDatesController.show().url
-              }
-            }
-          }
-
-          "have a section for contact details" which {
-
-            "has a contact details header" in {
-              elementText("#contact-details-section > h2") shouldBe viewMessages.contactDetailsHeading
-            }
-          }
-
-          "have a section for email address" which {
-
-            "has the heading" in {
-              elementText("#vat-email-address-text") shouldBe viewMessages.emailAddressHeading
-            }
-
-            "has the correct value for the email address" in {
-              elementText("#vat-email-address") shouldBe customerInformationModelMaxIndividual.ppob.contactDetails.get.emailAddress.get
-            }
-
-            "has a change link" which {
-
-              s"has the wording '${viewMessages.change}'" in {
-                elementText("#vat-email-address-status") shouldBe viewMessages.change
-              }
-
-              s"has the correct aria label text '${viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)}'" in {
-                element("#vat-email-address-status").attr("aria-label") shouldBe
-                  viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)
-              }
-
-              s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
-                element("#vat-email-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeEmailUrl
-              }
-            }
-          }
-
-          "have a section for phone numbers" which {
-
-            "has the heading" in {
-              elementText("#vat-phone-numbers-text") shouldBe viewMessages.phoneNumbersHeading
-            }
-
-            "has the correct value for the phone numbers" in {
-              elementText("#vat-phone-numbers") shouldBe
-                s"Landline: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.phoneNumber.get} " +
-                  s"Mobile: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.mobileNumber.get}"
-            }
-
-            "has a change link" which {
-
-              s"has the wording '${viewMessages.change}'" in {
-                elementText("#vat-phone-numbers-status") shouldBe viewMessages.change
-              }
-
-              s"has the correct aria label text '${viewMessages.changePhoneNumbersHidden}'" in {
-                element("#vat-phone-numbers-status").attr("aria-label") shouldBe
-                  viewMessages.changePhoneNumbersHidden
-              }
-
-              s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
-                element("#vat-phone-numbers-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangePhoneNumbersUrl
-              }
-            }
-          }
-
-          "have a section for website address" which {
-
-            "has the heading" in {
-              elementText("#vat-website-address-text") shouldBe viewMessages.websiteAddressHeading
-            }
-
-            "has the correct value for the website address" in {
-              elementText("#vat-website-address") shouldBe customerInformationModelMaxIndividual.ppob.websiteAddress.get
-            }
-
-            "has a change link" which {
-
-              s"has the wording '${viewMessages.change}'" in {
-                elementText("#vat-website-address-status") shouldBe viewMessages.change
-              }
-
-              s"has the correct aria label text '${viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)}'" in {
-                element("#vat-website-address-status").attr("aria-label") shouldBe
-                  viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)
-              }
-
-              s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
-                element("#vat-website-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeWebsiteUrl
-              }
-            }
-          }
-
-          "not display the 'change another clients details' link" in {
-            elementExtinct("#change-client-text")
-          }
-
-          "display a progressive disclosure" which {
-
-            "contains help text" which {
-
-              lazy val progressiveDisclosure = element("details")
-
-              "contains the correct text" in {
-                progressiveDisclosure.select("summary").text() shouldEqual viewMessages.changeNotListed
-              }
-
-              "contains content" which {
-
-                lazy val helpContent = progressiveDisclosure.select("div > p")
-
-                "displays the correct text" in {
-                  helpContent.text() shouldEqual viewMessages.helpText
+                "has a registration header" in {
+                  elementText("#registration-section > h2") shouldBe viewMessages.registrationStatusHeading
                 }
 
-                s"has a link to ${mockConfig.govUkChangeVatRegistrationDetails}" in {
-                  helpContent.select("a").attr("href") shouldEqual mockConfig.govUkChangeVatRegistrationDetails
+                "has a registration status header" in {
+                  elementText("#registration-status-text") shouldBe viewMessages.statusText
+                }
+
+                "displays the correct registration status" in {
+                  elementText("#registration-status") shouldBe viewMessages.registeredStatus
+                }
+              }
+
+              "has an about header" in {
+                elementText("#content > article > div:nth-child(2) > h2") shouldBe viewMessages.aboutHeading
+              }
+
+              "have a section for business address" which {
+
+                "has the heading" in {
+                  elementText("#businessAddressHeading") shouldBe viewMessages.businessAddressHeading
+                }
+
+                "has the correct address output" in {
+                  elementText("#businessAddress li:nth-child(1)") shouldBe customerInformationModelMaxIndividual.ppob.address.line1
+                  elementText("#businessAddress li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.ppob.address.line2.get
+                  elementText("#businessAddress li:nth-child(3)") shouldBe customerInformationModelMaxIndividual.ppob.address.postCode.get
+                }
+
+                "has a change link" which {
+
+                  s"has the wording '${viewMessages.change}'" in {
+                    elementText("#place-of-business-status") shouldBe viewMessages.change
+                  }
+
+                  s"has the correct aria label text '${viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)}'" in {
+                    element("#place-of-business-status").attr("aria-label") shouldBe viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)
+                  }
+
+                  s"has a link to ${controllers.routes.BusinessAddressController.show().url}" in {
+                    element("#place-of-business-status").attr("href") shouldBe controllers.routes.BusinessAddressController.show().url
+                  }
+                }
+              }
+
+              "have a section for repayment Bank Account details" which {
+
+                "has the heading" in {
+                  elementText("#bank-details-text") shouldBe viewMessages.bankDetailsHeading
+                }
+
+                "has a the correct Account Number" which {
+
+                  "has the correct heading for the Account Number" in {
+                    elementText("#bank-details li:nth-child(1)") shouldBe viewMessages.accountNumberHeading
+                  }
+
+                  "has the correct value for the account number" in {
+                    elementText("#bank-details li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.bankAccountNumber.get
+                  }
+                }
+
+                "has a the correct Sort Code" which {
+
+                  "has the correct heading for the Sort Code" in {
+                    elementText("#bank-details li:nth-child(3)") shouldBe viewMessages.sortcodeHeading
+                  }
+
+                  "has the correct value for the account number" in {
+                    elementText("#bank-details li:nth-child(4)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.sortCode.get
+                  }
+                }
+
+                "has a change link" which {
+
+                  s"has the wording '${viewMessages.change}'" in {
+                    elementText("#bank-details-status") shouldBe viewMessages.change
+                  }
+
+                  s"has the correct aria label text '${viewMessages.changeBankDetailsHidden}'" in {
+                    element("#bank-details-status").attr("aria-label") shouldBe viewMessages.changeBankDetailsHidden
+                  }
+
+                  s"has a link to ${controllers.routes.PaymentsController.sendToPayments().url}" in {
+                    element("#bank-details-status").attr("href") shouldBe controllers.routes.PaymentsController.sendToPayments().url
+                  }
+                }
+              }
+
+              "have a section for return frequency" which {
+
+                "has the correct heading" in {
+                  elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
+                }
+
+                "has the correct current frequency" in {
+                  elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
+                }
+
+                "has a change link" which {
+
+                  s"has the wording '${viewMessages.change}'" in {
+                    elementText("#vat-return-dates-status") shouldBe viewMessages.change
+                  }
+
+                  s"has a link to ${controllers.returnFrequency.routes.ChooseDatesController.show().url}" in {
+                    element("#vat-return-dates-status").attr("href") shouldBe controllers.returnFrequency.routes.ChooseDatesController.show().url
+                  }
+                }
+              }
+
+              "have a section for contact details" which {
+
+                "has a contact details header" in {
+                  elementText("#contact-details-section > h2") shouldBe viewMessages.contactDetailsHeading
+                }
+              }
+
+              "have a section for email address" which {
+
+                "has the heading" in {
+                  elementText("#vat-email-address-text") shouldBe viewMessages.emailAddressHeading
+                }
+
+                "has the correct value for the email address" in {
+                  elementText("#vat-email-address") shouldBe customerInformationModelMaxIndividual.ppob.contactDetails.get.emailAddress.get
+                }
+
+                "has a change link" which {
+
+                  s"has the wording '${viewMessages.change}'" in {
+                    elementText("#vat-email-address-status") shouldBe viewMessages.change
+                  }
+
+                  s"has the correct aria label text '${viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)}'" in {
+                    element("#vat-email-address-status").attr("aria-label") shouldBe
+                      viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)
+                  }
+
+                  s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
+                    element("#vat-email-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeEmailUrl
+                  }
+                }
+              }
+
+              "have a section for phone numbers" which {
+
+                "has the heading" in {
+                  elementText("#vat-phone-numbers-text") shouldBe viewMessages.phoneNumbersHeading
+                }
+
+                "has the correct value for the phone numbers" in {
+                  elementText("#vat-phone-numbers") shouldBe
+                    s"Landline: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.phoneNumber.get} " +
+                      s"Mobile: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.mobileNumber.get}"
+                }
+
+                "has a change link" which {
+
+                  s"has the wording '${viewMessages.change}'" in {
+                    elementText("#vat-phone-numbers-status") shouldBe viewMessages.change
+                  }
+
+                  s"has the correct aria label text '${viewMessages.changePhoneNumbersHidden}'" in {
+                    element("#vat-phone-numbers-status").attr("aria-label") shouldBe
+                      viewMessages.changePhoneNumbersHidden
+                  }
+
+                  s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
+                    element("#vat-phone-numbers-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangePhoneNumbersUrl
+                  }
+                }
+              }
+
+              "have a section for website address" which {
+
+                "has the heading" in {
+                  elementText("#vat-website-address-text") shouldBe viewMessages.websiteAddressHeading
+                }
+
+                "has the correct value for the website address" in {
+                  elementText("#vat-website-address") shouldBe customerInformationModelMaxIndividual.ppob.websiteAddress.get
+                }
+
+                "has a change link" which {
+
+                  s"has the wording '${viewMessages.change}'" in {
+                    elementText("#vat-website-address-status") shouldBe viewMessages.change
+                  }
+
+                  s"has the correct aria label text '${viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)}'" in {
+                    element("#vat-website-address-status").attr("aria-label") shouldBe
+                      viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)
+                  }
+
+                  s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
+                    element("#vat-website-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeWebsiteUrl
+                  }
+                }
+              }
+
+              "not display the 'change another clients details' link" in {
+                elementExtinct("#change-client-text")
+              }
+
+              "display a progressive disclosure" which {
+
+                "contains help text" which {
+
+                  lazy val progressiveDisclosure = element("details")
+
+                  "contains the correct text" in {
+                    progressiveDisclosure.select("summary").text() shouldEqual viewMessages.changeNotListed
+                  }
+
+                  "contains content" which {
+
+                    lazy val helpContent = progressiveDisclosure.select("div > p")
+
+                    "displays the correct text" in {
+                      helpContent.text() shouldEqual viewMessages.helpText
+                    }
+
+                    s"has a link to ${mockConfig.govUkChangeVatRegistrationDetails}" in {
+                      helpContent.select("a").attr("href") shouldEqual mockConfig.govUkChangeVatRegistrationDetails
+                    }
+                  }
+                }
+              }
+
+              "not display the making tax digital section" in {
+                elementExtinct("#mtd-section")
+              }
+            }
+
+            "useVatReturnPeriodFrontend feature switch is on" should {
+
+              lazy val view = {
+                mockConfig.features.useVatReturnPeriodFrontend(true)
+                views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
+              }
+
+              lazy implicit val document: Document = Jsoup.parse(view.body)
+
+              "have a section for return frequency" which {
+
+                s"has a change link to ${mockConfig.vatReturnPeriodFrontendUrl}" in {
+                  element("#vat-return-dates-status").attr("href") shouldBe mockConfig.vatReturnPeriodFrontendUrl
                 }
               }
             }
           }
         }
 
-        "useVatReturnPeriodFrontend feature switch is on" should {
+        "with pending changes" when {
 
-          lazy val view = {
-            mockConfig.features.useVatReturnPeriodFrontend(true)
-            views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
-          }
+          "deregistering" when {
 
-          lazy implicit val document: Document = Jsoup.parse(view.body)
+            "deregistration date is in the future" should {
 
-          "have a section for return frequency" which {
+              lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelFutureDereg)(user, messages, mockConfig)
+              lazy implicit val document: Document = Jsoup.parse(view.body)
 
-            s"has a change link to ${mockConfig.vatReturnPeriodFrontendUrl}" in {
-              element("#vat-return-dates-status").attr("href") shouldBe mockConfig.vatReturnPeriodFrontendUrl
+              "have a section for registration status" which {
+
+                "displays the correct registration status" in {
+                  elementText("#registration-status") shouldBe viewMessages.futureDereg(toLongDate(futureDate))
+                }
+
+                "has the 'how to register' link" in {
+                  elementText("#registration-status-link") shouldBe viewMessages.howToRegister
+                  element("#registration-status-link").attr("href") shouldBe "https://www.gov.uk/vat-registration/how-to-register"
+                }
+              }
+            }
+
+            "deregistration is still pending" should {
+
+              lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelDeregPending)(user, messages, mockConfig)
+              lazy implicit val document: Document = Jsoup.parse(view.body)
+
+              "have a section for registration status" which {
+
+                "displays the correct registration status" in {
+                  elementText("#registration-status") shouldBe viewMessages.deregPending
+                }
+
+                "states that the decision is 'pending'" in {
+                  elementText("#registration-status-link") shouldBe viewMessages.pending
+                }
+              }
+
+              "have a section for return frequency" which {
+
+                "has the heading" in {
+                  elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
+                }
+
+                "has the correct value output for the current frequency" in {
+                  elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
+                }
+
+                "has no change link or pending status" in {
+                  document.select("#vat-return-dates-status").isEmpty shouldBe true
+                }
+              }
             }
           }
         }
@@ -338,621 +404,211 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
           }
         }
       }
-    }
 
-    "for a user with a future deregistration date" should {
+      "with no email address, phone number or website" should {
 
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelFutureDereg)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "have a section for registration status" which {
-
-        "displays the correct registration status" in {
-          elementText("#registration-status") shouldBe viewMessages.futureDereg(toLongDate(futureDate))
-        }
-
-        "has the 'how to register' link" in {
-          elementText("#registration-status-link") shouldBe viewMessages.howToRegister
-          element("#registration-status-link").attr("href") shouldBe "https://www.gov.uk/vat-registration/how-to-register"
-        }
-      }
-    }
-
-    "for a user with a pending deregistration" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelDeregPending)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "have a section for registration status" which {
-
-        "displays the correct registration status" in {
-          elementText("#registration-status") shouldBe viewMessages.deregPending
-        }
-
-        "states that the decision is 'pending'" in {
-          elementText("#registration-status-link") shouldBe viewMessages.pending
-        }
-      }
-
-      "have a section for return frequency" which {
-
-        "has the heading" in {
-          elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
-        }
-
-        "has the correct value output for the current frequency" in {
-          elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
-        }
-
-        "has no change link or pending status" in {
-          document.select("#vat-return-dates-status").isEmpty shouldBe true
-        }
-      }
-    }
-
-    "viewing for an individual with no email address, phone number or website" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelMin)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "display the 'Not provided' text in place of the email address" in {
-        elementText("#vat-email-address") shouldBe "Not provided"
-      }
-
-      "display an 'Add' link for changing the email address" which {
-
-        "has the correct text" in {
-          elementText("#vat-email-address-status") shouldBe "Add"
-        }
-
-        "links to the correspondence details service" in {
-          element("#vat-email-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeEmailUrl
-        }
-      }
-
-      "display the 'Not provided' text in place of the phone numbers" in {
-        elementText("#vat-phone-numbers") shouldBe "Landline: Not provided Mobile: Not provided"
-      }
-
-      "display an 'Add' link for changing the phone numbers" which {
-
-        "has the correct text" in {
-          elementText("#vat-phone-numbers-status") shouldBe "Add"
-        }
-
-        "links to the correspondence details service" in {
-          element("#vat-phone-numbers-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangePhoneNumbersUrl
-        }
-      }
-
-      "display the 'Not provided' text in place of the website address" in {
-        elementText("#vat-website-address") shouldBe "Not provided"
-      }
-
-      "display an 'Add' link for changing the website address" which {
-
-        "has the correct text" in {
-          elementText("#vat-website-address-status") shouldBe "Add"
-        }
-
-        "links to the correspondence details service" in {
-          element("#vat-website-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeWebsiteUrl
-        }
-      }
-    }
-
-    "Viewing for an Organisation with pending changes" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelOrganisationPending)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "display a breadcrumb trail" in {
-        elementText(".breadcrumbs li:nth-of-type(1)") shouldBe breadcrumbBta
-        elementText(".breadcrumbs li:nth-of-type(2)") shouldBe breadcrumbVat
-        elementText(".breadcrumbs li:nth-of-type(3)") shouldBe breadcrumbBizDeets
-      }
-
-      "have a section for business address" which {
-
-        "has the heading" in {
-          elementText("#businessAddressHeading") shouldBe viewMessages.businessAddressHeading
-        }
-
-        "has the correct address output" in {
-          elementText("#businessAddress li:nth-child(1)") shouldBe customerInformationModelOrganisationPending.pendingChanges.get.ppob.get.address.line1
-          elementText("#businessAddress li:nth-child(2)") shouldBe customerInformationModelOrganisationPending.pendingChanges.get.ppob.get.address.line2.get
-          elementText("#businessAddress li:nth-child(3)") shouldBe customerInformationModelOrganisationPending.pendingChanges.get.ppob.get.address.postCode.get
-        }
-
-        "has Pending instead of a change link" which {
-
-          s"has the wording '${viewMessages.pending}'" in {
-            elementText("#place-of-business-status") shouldBe viewMessages.pending
-          }
-
-          s"has the correct aria label text '${viewMessages.pendingBusinessAddressHidden}'" in {
-            element("#place-of-business-status").attr("aria-label") shouldBe viewMessages.pendingBusinessAddressHidden
-          }
-
-          s"has no link" in {
-            element("#place-of-business-status").attr("href").isEmpty shouldBe true
-          }
-        }
-      }
-
-      "have a section for repayment Bank Account details" which {
-
-        "has the heading" in {
-          elementText("#bank-details-text") shouldBe viewMessages.bankDetailsHeading
-        }
-
-        "has a the correct Account Number" which {
-
-          "has the correct heading for the Account Number" in {
-            elementText("#bank-details li:nth-child(1)") shouldBe viewMessages.accountNumberHeading
-          }
-
-          "has the correct value for the account number" in {
-            elementText("#bank-details li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.bankAccountNumber.get
-          }
-        }
-
-        "has the correct Sort Code" which {
-
-          "has the correct heading for the Sort Code" in {
-            elementText("#bank-details li:nth-child(3)") shouldBe viewMessages.sortcodeHeading
-          }
-
-          "has the correct value for the account number" in {
-            elementText("#bank-details li:nth-child(4)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.sortCode.get
-          }
-        }
-
-        "has Pending instead of a change link" which {
-
-          s"has the wording '${viewMessages.pending}'" in {
-            elementText("#bank-details-status") shouldBe viewMessages.pending
-          }
-
-          s"has the correct aria label text '${viewMessages.pendingBankDetailsHidden}'" in {
-            element("#bank-details-status").attr("aria-label") shouldBe viewMessages.pendingBankDetailsHidden
-          }
-
-          s"has no link" in {
-            element("#bank-details-status").attr("href").isEmpty shouldBe true
-          }
-        }
-      }
-
-      "have a section for return frequency" which {
-
-        "has the heading" in {
-          elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
-        }
-
-        "has the correct value output for the current frequency" in {
-          elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
-        }
-
-        "has Pending instead of a change link" which {
-
-          s"has the wording '${viewMessages.pending}'" in {
-            elementText("#vat-return-dates-status") shouldBe viewMessages.pending
-          }
-
-          s"has the correct aria label text '${viewMessages.pendingReturnFrequencyHidden}'" in {
-            element("#vat-return-dates-status").attr("aria-label") shouldBe viewMessages.pendingReturnFrequencyHidden
-          }
-
-          s"has no link" in {
-            element("#vat-return-dates-status").attr("href").isEmpty shouldBe true
-          }
-        }
-      }
-
-      "have a section for contact details" which {
-
-        "has a contact details header" in {
-          elementText("#contact-details-section > h2") shouldBe viewMessages.contactDetailsHeading
-        }
-      }
-
-      "have a section for email address" which {
-
-        "has the heading" in {
-          elementText("#vat-email-address-text") shouldBe viewMessages.emailAddressHeading
-        }
-
-        "has the correct value for the email address" in {
-          elementText("#vat-email-address") shouldBe customerInformationModelOrganisationPending.pendingChanges.
-            get.ppob.get.contactDetails.get.emailAddress.get
-        }
-
-        s"has the correct aria label text '${viewMessages.pendingEmailAddressHidden}'" in {
-          element("#vat-email-address-status").attr("aria-label") shouldBe viewMessages.pendingEmailAddressHidden
-        }
-      }
-
-      "have a section for phone numbers" which {
-
-        "has the heading" in {
-          elementText("#vat-phone-numbers-text") shouldBe viewMessages.phoneNumbersHeading
-        }
-
-        "has the correct value for the phone numbers" in {
-          elementText("#vat-phone-numbers") shouldBe
-            s"Landline: ${customerInformationModelOrganisationPending.pendingChanges.get.ppob.get.contactDetails.get.phoneNumber.get} " +
-            s"Mobile: ${customerInformationModelOrganisationPending.pendingChanges.get.ppob.get.contactDetails.get.mobileNumber.get}"
-        }
-
-        s"has the correct aria label text '${viewMessages.pendingPhoneNumbersHidden}'" in {
-          element("#vat-phone-numbers-status").attr("aria-label") shouldBe viewMessages.pendingPhoneNumbersHidden
-        }
-      }
-
-      "have a section for website address" which {
-
-        "has the heading" in {
-          elementText("#vat-website-address-text") shouldBe viewMessages.websiteAddressHeading
-        }
-
-        "has the correct value for the website address" in {
-          elementText("#vat-website-address") shouldBe
-            customerInformationModelOrganisationPending.pendingChanges.get.ppob.get.websiteAddress.get
-        }
-
-        s"has the correct aria label text '${viewMessages.pendingWebsiteAddressHidden}'" in {
-          element("#vat-website-address-status").attr("aria-label") shouldBe viewMessages.pendingWebsiteAddressHidden
-        }
-      }
-
-      "not display the 'change another clients details' link" in {
-        elementExtinct("#change-client-text")
-      }
-    }
-
-    "Viewing for an Organisation with one of the valid partyTypes" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(Some("2")))(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "have a change details section for the Business Name" which {
-
-        s"has the heading '${viewMessages.organisationNameHeading}'" in {
-          elementText("#business-name-text") shouldBe viewMessages.organisationNameHeading
-        }
-      }
-    }
-
-    "Viewing for a user with one of the valid partyTypes but no organisation name" should {
-
-      val model: CircumstanceDetails = CircumstanceDetails(
-        mandationStatus = MTDfBMandated,
-        customerDetails = individual,
-        flatRateScheme = None,
-        ppob = ppobModelMax,
-        bankDetails = None,
-        returnPeriod = None,
-        deregistration = None,
-        changeIndicators = None,
-        pendingChanges = None,
-        partyType = Some(mockConfig.partyTypes.head)
-      )
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(model)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "not have a change details section for the Business Name" in {
-        document.select("#business-name-text").isEmpty shouldBe true
-      }
-    }
-
-    "Viewing for an Organisation with a different valid partyType" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(Some("4")))(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "have a change details section for the Business Name" which {
-
-        s"has the heading '${viewMessages.organisationNameHeading}'" in {
-          elementText("#business-name-text") shouldBe viewMessages.organisationNameHeading
-        }
-      }
-    }
-
-    "Viewing for an Organisation without one of the valid partyTypes" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(Some("other")))(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "not have a change details section for the Business Name" in {
-        document.select("#business-name-text").isEmpty shouldBe true
-      }
-    }
-
-    "Viewing for an Organisation without any partyType" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(None))(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "have no change details section for the Business Name" in {
-        document.select("#business-name-text").isEmpty shouldBe true
-      }
-    }
-
-    "Viewing a client's details as an agent with changeClient feature switch on" when {
-
-      "the allowAgentBankAccountChange feature is set to false" should {
-
-        lazy val view = {
-          mockConfig.features.changeClientFeature(true)
-          views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(agentUser, messages, mockConfig)
-        }
+        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelMin)(user, messages, mockConfig)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
-        "not display a breadcrumb trail" in {
-          elementExtinct(".breadcrumbs li:nth-of-type(1)")
-          elementExtinct(".breadcrumbs li:nth-of-type(2)")
-          elementExtinct(".breadcrumbs li:nth-of-type(3)")
+        "display the 'Not provided' text in place of the email address" in {
+          elementText("#vat-email-address") shouldBe "Not provided"
         }
 
-        s"have the correct document title '${viewMessages.title}'" in {
-          document.title shouldBe viewMessages.agentTitle
-        }
+        "display an 'Add' link for changing the email address" which {
 
-        "have the correct service name" in {
-          elementText(".header__menu__proposition-name") shouldBe agentServiceName
-        }
+          "has the correct text" in {
+            elementText("#vat-email-address-status") shouldBe "Add"
+          }
 
-        s"have a the correct page heading '${viewMessages.agentHeading}'" in {
-          elementText("h1") shouldBe viewMessages.agentHeading
-        }
-
-        "display the 'Change client' link" in {
-          elementText("#change-client-text") shouldBe viewMessages.newChangeClientDetails
-          element("#change-client-link").attr("href") shouldBe
-            controllers.agentClientRelationship.routes.ConfirmClientVrnController.changeClient().url
-        }
-
-        "display the Finish button" in {
-          val finishSelector = "#finish"
-          elementText(finishSelector) shouldBe viewMessages.finish
-          element(finishSelector).attr("href") shouldBe "/agent-action"
-        }
-
-        "not display the Change Bank Account details row" which {
-
-          "is not found in the document" in {
-            document.select("#bank-details-text") shouldBe empty
+          "links to the correspondence details service" in {
+            element("#vat-email-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeEmailUrl
           }
         }
 
-        "have a blank field where the 'Change' link would be for email address" which {
+        "display the 'Not provided' text in place of the phone numbers" in {
+          elementText("#vat-phone-numbers") shouldBe "Landline: Not provided Mobile: Not provided"
+        }
 
-          "displays no text" in {
-            elementText("#vat-email-address-status") shouldBe ""
+        "display an 'Add' link for changing the phone numbers" which {
+
+          "has the correct text" in {
+            elementText("#vat-phone-numbers-status") shouldBe "Add"
           }
 
-          s"has the correct aria-label text '${viewMessages.changeEmailAddressAgentHidden}'" in {
-            element("#vat-email-address-status").attr("aria-label") shouldBe viewMessages.changeEmailAddressAgentHidden
+          "links to the correspondence details service" in {
+            element("#vat-phone-numbers-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangePhoneNumbersUrl
           }
         }
-      }
 
-      "the allowAgentBankAccountChange feature is set to false" should {
+        "display the 'Not provided' text in place of the website address" in {
+          elementText("#vat-website-address") shouldBe "Not provided"
+        }
 
-        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(agentUser, messages, mockConfig)
-        lazy implicit val document: Document = Jsoup.parse(view.body)
+        "display an 'Add' link for changing the website address" which {
 
-        "display the Change Bank Account details row" in {
-          mockConfig.features.allowAgentBankAccountChange(true)
-          elementText("#bank-details-text") shouldBe viewMessages.bankDetailsHeading
+          "has the correct text" in {
+            elementText("#vat-website-address-status") shouldBe "Add"
+          }
+
+          "links to the correspondence details service" in {
+            element("#vat-website-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeWebsiteUrl
+          }
         }
       }
     }
 
-    "Viewing a client's details as an agent with changeClient feature switch off" when {
+    "an Organisation" when {
 
-      "the allowAgentBankAccountChange feature is set to false" should {
+      "with a valid party type" when {
+
+        "with an organisation name" should {
+
+          "have a change details section for the Business Name" which {
+
+            lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(Some("2")))(user, messages, mockConfig)
+            lazy implicit val document: Document = Jsoup.parse(view.body)
+
+            s"has the heading '${viewMessages.organisationNameHeading}'" in {
+              elementText("#business-name-text") shouldBe viewMessages.organisationNameHeading
+            }
+          }
+        }
+
+        "with no organisation name" should {
+
+          val model: CircumstanceDetails = CircumstanceDetails(
+            mandationStatus = MTDfBMandated,
+            customerDetails = individual,
+            flatRateScheme = None,
+            ppob = ppobModelMax,
+            bankDetails = None,
+            returnPeriod = None,
+            deregistration = None,
+            changeIndicators = None,
+            pendingChanges = None,
+            partyType = Some(mockConfig.partyTypes.head)
+          )
+
+          lazy val view = views.html.customerInfo.customer_circumstance_details(model)(user, messages, mockConfig)
+          lazy implicit val document: Document = Jsoup.parse(view.body)
+
+          "not have a change details section for the Business Name" in {
+            document.select("#business-name-text").isEmpty shouldBe true
+          }
+        }
+      }
+
+      "without a valid party type" should {
+
+        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(Some("other")))(user, messages, mockConfig)
+        lazy implicit val document: Document = Jsoup.parse(view.body)
+
+        "not have a change details section for the Business Name" in {
+          document.select("#business-name-text").isEmpty shouldBe true
+        }
+      }
+
+      "without a party type" should {
+
+        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(None))(user, messages, mockConfig)
+        lazy implicit val document: Document = Jsoup.parse(view.body)
+
+        "have no change details section for the Business Name" in {
+          document.select("#business-name-text").isEmpty shouldBe true
+        }
+      }
+    }
+
+    "an Agent" when {
+
+      "changeClient feature switch is on" when {
+
+        "the allowAgentBankAccountChange feature is set to true" should {
+
+          lazy val view = {
+            mockConfig.features.changeClientFeature(true)
+            mockConfig.features.allowAgentBankAccountChange(true)
+            views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(agentUser, messages, mockConfig)
+          }
+
+          lazy implicit val document: Document = Jsoup.parse(view.body)
+
+          "not display a breadcrumb trail" in {
+            elementExtinct(".breadcrumbs li:nth-of-type(1)")
+            elementExtinct(".breadcrumbs li:nth-of-type(2)")
+            elementExtinct(".breadcrumbs li:nth-of-type(3)")
+          }
+
+          s"have the correct document title '${viewMessages.title}'" in {
+            document.title shouldBe viewMessages.agentTitle
+          }
+
+          "have the correct service name" in {
+            elementText(".header__menu__proposition-name") shouldBe agentServiceName
+          }
+
+          s"have a the correct page heading '${viewMessages.agentHeading}'" in {
+            elementText("h1") shouldBe viewMessages.agentHeading
+          }
+
+          "display the 'Change client' link" in {
+            elementText("#change-client-text") shouldBe viewMessages.newChangeClientDetails
+            element("#change-client-link").attr("href") shouldBe
+              controllers.agentClientRelationship.routes.ConfirmClientVrnController.changeClient().url
+          }
+
+          "display the Finish button" in {
+            val finishSelector = "#finish"
+            elementText(finishSelector) shouldBe viewMessages.finish
+            element(finishSelector).attr("href") shouldBe "/agent-action"
+          }
+
+          "have a blank field where the 'Change' link would be for email address" which {
+
+            "displays no text" in {
+              elementText("#vat-email-address-status") shouldBe ""
+            }
+
+            s"has the correct aria-label text '${viewMessages.changeEmailAddressAgentHidden}'" in {
+              element("#vat-email-address-status").attr("aria-label") shouldBe viewMessages.changeEmailAddressAgentHidden
+            }
+          }
+        }
+
+        "the allowAgentBankAccountChange feature is set to false" should {
+
+          lazy val view = {
+            mockConfig.features.changeClientFeature(true)
+            mockConfig.features.allowAgentBankAccountChange(false)
+            views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(agentUser, messages, mockConfig)
+          }
+
+          lazy implicit val document: Document = Jsoup.parse(view.body)
+
+          "not display the Change Bank Account details row" in {
+            elementExtinct("#bank-details-text")
+          }
+        }
+      }
+
+      "changeClient feature switch is off" should {
 
         lazy val view = {
           mockConfig.features.changeClientFeature(false)
-          mockConfig.features.allowAgentBankAccountChange(false)
           views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(agentUser, messages, mockConfig)
         }
+
         lazy implicit val document: Document = Jsoup.parse(view.body)
-
-        "not display a breadcrumb trail" in {
-          elementExtinct(".breadcrumbs li:nth-of-type(1)")
-          elementExtinct(".breadcrumbs li:nth-of-type(2)")
-          elementExtinct(".breadcrumbs li:nth-of-type(3)")
-        }
-
-        s"have the correct document title '${viewMessages.agentTitle}'" in {
-          document.title shouldBe viewMessages.agentTitle
-        }
-
-        "have the correct service name" in {
-          elementText(".header__menu__proposition-name") shouldBe agentServiceName
-        }
-
-        s"have a the correct page heading '${viewMessages.agentHeading}'" in {
-          elementText("h1") shouldBe viewMessages.agentHeading
-        }
-
-        "display the 'change another clients details' link" in {
-          elementText("#change-client-text") shouldBe viewMessages.oldChangeClientDetails
-          element("#change-client-link").attr("href") shouldBe
-            controllers.agentClientRelationship.routes.ConfirmClientVrnController.changeClient().url
-        }
 
         "not display the Finish button" in {
           val finishSelector = "#finish-button"
           elementExtinct(finishSelector)
         }
-
-        "not display the Change Bank Account details row" which {
-
-          "is not found in the document" in {
-            document.select("#bank-details-text") shouldBe empty
-          }
-        }
-
-        "have a blank field where the 'Change' link would be for email address" which {
-
-          "displays no text" in {
-            elementText("#vat-email-address-status") shouldBe ""
-          }
-
-          s"has the correct aria-label text '${viewMessages.changeEmailAddressAgentHidden}'" in {
-            element("#vat-email-address-status").attr("aria-label") shouldBe viewMessages.changeEmailAddressAgentHidden
-          }
-        }
       }
 
-      "the allowAgentBankAccountChange feature is set to false" should {
+      "client is MTD" should {
 
-        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(agentUser, messages, mockConfig)
-        lazy implicit val document: Document = Jsoup.parse(view.body)
-
-        "display the Change Bank Account details row" in {
-          mockConfig.features.allowAgentBankAccountChange(true)
-          elementText("#bank-details-text") shouldBe viewMessages.bankDetailsHeading
-        }
-      }
-    }
-
-    "the registration feature switch is disabled" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "not have a registration section" in {
-        mockConfig.features.registrationStatus(false)
-        elementText("div.form-group:nth-child(2) > h2:nth-child(1)") shouldBe viewMessages.aboutHeading
-        document.select("#registration-status-text").isEmpty shouldBe true
-        document.select("#registration-status").isEmpty shouldBe true
-        document.select("#registration-status-link").isEmpty shouldBe true
-      }
-    }
-
-    "the registration status is true" should {
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationRegisteredIndividual)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "have a section for return frequency" which {
-
-        "has the heading" in {
-          elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
-        }
-
-        "has the correct value output for the current frequency" in {
-          elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
-        }
-
-        "has a change link" which {
-
-          s"has the wording '${viewMessages.change}'" in {
-            elementText("#vat-return-dates-status") shouldBe viewMessages.change
-          }
-
-          s"has the correct aria label text '${viewMessages.changeReturnFrequencyHidden(ReturnFrequencyMessages.option3Mar)}'" in {
-            element("#vat-return-dates-status").attr("aria-label") shouldBe viewMessages.changeReturnFrequencyHidden(ReturnFrequencyMessages.option3Mar)
-          }
-
-          s"has a link to ${controllers.routes.BusinessAddressController.initialiseJourney().url}" in {
-            element("#vat-return-dates-status").attr("href") shouldBe controllers.returnFrequency.routes.ChooseDatesController.show().url
-          }
-        }
-      }
-    }
-
-    "the registration status is false deregistration set to a future date" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelFutureDereg)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "not have a registration section" in {
-        mockConfig.features.registrationStatus(true)
-        elementText(".panel > p:nth-child(1)") shouldBe viewMessages.futureDeregDateText(futureDate.toLongDate)
-
-      }
-    }
-
-    "the registration status is false - deregistration set to a past date" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividualDeregistered)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "registration section displays the following" in {
-        mockConfig.features.registrationStatus(true)
-        elementText(".panel > p:nth-child(1)") shouldBe viewMessages.pastDeregDateText(pastDate.toLongDate)
-        elementText("#registration-status")
-        elementText("#registration-status-link") shouldBe viewMessages.howToRegister
-        elementText("#registration-status-text") shouldBe viewMessages.statusText
-        elementText("div.form-group:nth-child(5) > h2:nth-child(1)") shouldBe viewMessages.registrationStatusHeading
-      }
-    }
-
-    "the registration status is false deregistration set to a pending" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelDeregPending)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "registration section displays the following" in {
-        mockConfig.features.registrationStatus(true)
-        elementText("#registration-status-link") shouldBe viewMessages.pending
-        elementText("#registration-status") shouldBe viewMessages.deregPending
-      }
-    }
-
-    "the registration status is true" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationWithPartyType(Some("2")))(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "registration section displays the following" in {
-        mockConfig.features.registrationStatus(true)
-        elementText("#registration-status-link") shouldBe viewMessages.deregister
-        elementText("#business-name-status") shouldBe viewMessages.change
-        elementText("#place-of-business-status") shouldBe viewMessages.change
-        elementText("#bank-details-status") shouldBe viewMessages.change
-        elementText("#vat-return-dates-status") shouldBe viewMessages.change
-      }
-    }
-
-    "the contact details feature switch is false" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "contact details section is hidden" in {
-        mockConfig.features.contactDetailsSection(false)
-        elementExtinct("#contact-details-section")
-      }
-    }
-
-    "the showPhoneNumbersAndWebsite feature switch is false" should {
-
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
-
-      "the phone numbers section is hidden" in {
-        mockConfig.features.showContactNumbersAndWebsite(false)
-        elementExtinct("#vat-phone-numbers")
-      }
-
-      "the website section is hidden" in {
-        mockConfig.features.showContactNumbersAndWebsite(false)
-        elementExtinct("#vat-website-address")
-      }
-    }
-
-    "the making tax digital feature switch is true" when {
-
-      "the user is an agent" should {
-
-        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(agentUser, messages, mockConfig)
+        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationRegisteredIndividual)(agentUser, messages, mockConfig)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
         "have a section for making tax digital" which {
@@ -986,24 +642,60 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
         }
       }
 
-      "the user is not an agent" should {
+      "client is non-MTDfB" should {
 
-        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(user, messages, mockConfig)
+        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNonMtd)(user, messages, mockConfig)
         lazy implicit val document: Document = Jsoup.parse(view.body)
 
-        "not display the making tax digital section" in {
+        "hide the making tax digital section" in {
           elementExtinct("#mtd-section")
         }
       }
     }
 
-    "the user has a non-MTD mandation status" should {
+    "the registrationStatus feature switch is disabled" should {
 
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNonMtd)(user, messages, mockConfig)
+      lazy val view = {
+        mockConfig.features.registrationStatus(false)
+        views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
+      }
+
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
-      "hide the making tax digital section" in {
-        elementExtinct("#mtd-section")
+      "not have a registration section" in {
+        elementExtinct("#registration-section")
+      }
+    }
+
+    "the contactDetailsSection feature switch is disabled" should {
+
+      lazy val view = {
+        mockConfig.features.contactDetailsSection(false)
+        views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(user, messages, mockConfig)
+      }
+
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "contact details section is hidden" in {
+        elementExtinct("#contact-details-section")
+      }
+    }
+
+    "the showPhoneNumbersAndWebsite feature switch is disabled" should {
+
+      lazy val view = {
+        mockConfig.features.showContactNumbersAndWebsite(false)
+        views.html.customerInfo.customer_circumstance_details(customerInformationModelMaxIndividual)(user, messages, mockConfig)
+      }
+
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "the phone numbers section is hidden" in {
+        elementExtinct("#vat-phone-numbers")
+      }
+
+      "the website section is hidden" in {
+        elementExtinct("#vat-website-address")
       }
     }
 
@@ -1026,7 +718,6 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
       "not give the option to change PPOB" in {
         elementExtinct("#place-of-business-status")
       }
-
     }
   }
 }

--- a/test/views/customerInfo/CustomerCircumstanceDetailsViewSpec.scala
+++ b/test/views/customerInfo/CustomerCircumstanceDetailsViewSpec.scala
@@ -32,249 +32,309 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
 
   "Rendering the Customer Details page" when {
 
-    mockConfig.features.registrationStatus(true)
-    mockConfig.features.contactDetailsSection(true)
-    mockConfig.features.showContactNumbersAndWebsite(true)
-    mockConfig.features.allowAgentBankAccountChange(false)
-    mockConfig.features.useLanguageSelector(true)
+    "Viewing for an Individual without any pending changes" when {
 
-    "Viewing for an Individual without any pending changes" should {
+      "registered for VAT" when {
 
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
-      lazy implicit val document: Document = Jsoup.parse(view.body)
+        "useVatReturnPeriodFrontend feature switch is off" should {
 
-      s"have the correct document title '${viewMessages.title}'" in {
-        document.title shouldBe viewMessages.title
-      }
+          lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
+          lazy implicit val document: Document = Jsoup.parse(view.body)
 
-      "have the correct service name" in {
-        elementText(".header__menu__proposition-name") shouldBe clientServiceName
-      }
-
-      s"have a the correct page heading '${viewMessages.heading}'" in {
-        elementText("h1") shouldBe viewMessages.heading
-      }
-
-      "display a breadcrumb trail which" in {
-        elementText(".breadcrumbs li:nth-of-type(1)") shouldBe breadcrumbBta
-        elementText(".breadcrumbs li:nth-of-type(2)") shouldBe breadcrumbVat
-        elementText(".breadcrumbs li:nth-of-type(3)") shouldBe breadcrumbBizDeets
-
-        element("#breadcrumb-bta").attr("href") shouldBe "ye olde bta url"
-        element("#breadcrumb-vat").attr("href") shouldBe "ye olde vat summary url"
-      }
-
-      "have a section for registration status" which {
-
-        "has a registration header" in {
-          elementText("#registration-section > h2") shouldBe viewMessages.registrationStatusHeading
-        }
-
-        "has a registration status header" in {
-          elementText("#registration-status-text") shouldBe viewMessages.statusText
-        }
-
-        "displays the correct registration status" in {
-          elementText("#registration-status") shouldBe viewMessages.deregStatus(toLongDate(pastDate))
-        }
-
-        "has the 'how to register' link" in {
-          elementText("#registration-status-link") shouldBe viewMessages.howToRegister
-          element("#registration-status-link").attr("href") shouldBe "https://www.gov.uk/vat-registration/how-to-register"
-        }
-      }
-
-      "has an about header" in {
-        elementText("#content > article > div:nth-child(3) > h2") shouldBe viewMessages.aboutHeading
-      }
-
-      "have a section for business address" which {
-
-        "has the heading" in {
-          elementText("#businessAddressHeading") shouldBe viewMessages.businessAddressHeading
-        }
-
-        "has the correct address output" in {
-          elementText("#businessAddress li:nth-child(1)") shouldBe customerInformationModelMaxIndividual.ppob.address.line1
-          elementText("#businessAddress li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.ppob.address.line2.get
-          elementText("#businessAddress li:nth-child(3)") shouldBe customerInformationModelMaxIndividual.ppob.address.postCode.get
-        }
-
-        "has a change link" which {
-
-          s"has the wording '${viewMessages.change}'" in {
-            elementText("#place-of-business-status") shouldBe viewMessages.change
+          s"have the correct document title '${viewMessages.title}'" in {
+            document.title shouldBe viewMessages.title
           }
 
-          s"has the correct aria label text '${viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)}'" in {
-            element("#place-of-business-status").attr("aria-label") shouldBe viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)
+          "have the correct service name" in {
+            elementText(".header__menu__proposition-name") shouldBe clientServiceName
           }
 
-          s"has a link to ${controllers.routes.BusinessAddressController.show().url}" in {
-            element("#place-of-business-status").attr("href") shouldBe controllers.routes.BusinessAddressController.show().url
-          }
-        }
-      }
-
-      "have a section for repayment Bank Account details" which {
-
-        "has the heading" in {
-          elementText("#bank-details-text") shouldBe viewMessages.bankDetailsHeading
-        }
-
-        "has a the correct Account Number" which {
-
-          "has the correct heading for the Account Number" in {
-            elementText("#bank-details li:nth-child(1)") shouldBe viewMessages.accountNumberHeading
+          s"have a the correct page heading '${viewMessages.heading}'" in {
+            elementText("h1") shouldBe viewMessages.heading
           }
 
-          "has the correct value for the account number" in {
-            elementText("#bank-details li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.bankAccountNumber.get
-          }
-        }
+          "display a breadcrumb trail which" in {
+            elementText(".breadcrumbs li:nth-of-type(1)") shouldBe breadcrumbBta
+            elementText(".breadcrumbs li:nth-of-type(2)") shouldBe breadcrumbVat
+            elementText(".breadcrumbs li:nth-of-type(3)") shouldBe breadcrumbBizDeets
 
-        "has a the correct Sort Code" which {
-
-          "has the correct heading for the Sort Code" in {
-            elementText("#bank-details li:nth-child(3)") shouldBe viewMessages.sortcodeHeading
+            element("#breadcrumb-bta").attr("href") shouldBe "ye olde bta url"
+            element("#breadcrumb-vat").attr("href") shouldBe "ye olde vat summary url"
           }
 
-          "has the correct value for the account number" in {
-            elementText("#bank-details li:nth-child(4)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.sortCode.get
-          }
-        }
+          "have a section for registration status" which {
 
-        "has a change link" which {
-
-          s"has the wording '${viewMessages.change}'" in {
-            elementText("#bank-details-status") shouldBe viewMessages.change
-          }
-
-          s"has the correct aria label text '${viewMessages.changeBankDetailsHidden}'" in {
-            element("#bank-details-status").attr("aria-label") shouldBe viewMessages.changeBankDetailsHidden
-          }
-
-          s"has a link to ${controllers.routes.PaymentsController.sendToPayments().url}" in {
-            element("#bank-details-status").attr("href") shouldBe controllers.routes.PaymentsController.sendToPayments().url
-          }
-        }
-      }
-
-      "have a section for contact details" which {
-
-        "has a contact details header" in {
-          elementText("#contact-details-section > h2") shouldBe viewMessages.contactDetailsHeading
-        }
-      }
-
-      "have a section for email address" which {
-
-        "has the heading" in {
-          elementText("#vat-email-address-text") shouldBe viewMessages.emailAddressHeading
-        }
-
-        "has the correct value for the email address" in {
-          elementText("#vat-email-address") shouldBe customerInformationModelMaxIndividual.ppob.contactDetails.get.emailAddress.get
-        }
-
-        "has a change link" which {
-
-          s"has the wording '${viewMessages.change}'" in {
-            elementText("#vat-email-address-status") shouldBe viewMessages.change
-          }
-
-          s"has the correct aria label text '${viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)}'" in {
-            element("#vat-email-address-status").attr("aria-label") shouldBe
-              viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)
-          }
-
-          s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
-            element("#vat-email-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeEmailUrl
-          }
-        }
-      }
-
-      "have a section for phone numbers" which {
-
-        "has the heading" in {
-          elementText("#vat-phone-numbers-text") shouldBe viewMessages.phoneNumbersHeading
-        }
-
-        "has the correct value for the phone numbers" in {
-          elementText("#vat-phone-numbers") shouldBe
-            s"Landline: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.phoneNumber.get} " +
-            s"Mobile: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.mobileNumber.get}"
-        }
-
-        "has a change link" which {
-
-          s"has the wording '${viewMessages.change}'" in {
-            elementText("#vat-phone-numbers-status") shouldBe viewMessages.change
-          }
-
-          s"has the correct aria label text '${viewMessages.changePhoneNumbersHidden}'" in {
-            element("#vat-phone-numbers-status").attr("aria-label") shouldBe
-              viewMessages.changePhoneNumbersHidden
-          }
-
-          s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
-            element("#vat-phone-numbers-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangePhoneNumbersUrl
-          }
-        }
-      }
-
-      "have a section for website address" which {
-
-        "has the heading" in {
-          elementText("#vat-website-address-text") shouldBe viewMessages.websiteAddressHeading
-        }
-
-        "has the correct value for the website address" in {
-          elementText("#vat-website-address") shouldBe customerInformationModelMaxIndividual.ppob.websiteAddress.get
-        }
-
-        "has a change link" which {
-
-          s"has the wording '${viewMessages.change}'" in {
-            elementText("#vat-website-address-status") shouldBe viewMessages.change
-          }
-
-          s"has the correct aria label text '${viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)}'" in {
-            element("#vat-website-address-status").attr("aria-label") shouldBe
-              viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)
-          }
-
-          s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
-            element("#vat-website-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeWebsiteUrl
-          }
-        }
-      }
-
-      "not display the 'change another clients details' link" in {
-        elementExtinct("#change-client-text")
-      }
-
-      "display a progressive disclosure" which {
-
-        "contains help text" which {
-
-          lazy val progressiveDisclosure = element("details")
-
-          "contains the correct text" in {
-            progressiveDisclosure.select("summary").text() shouldEqual viewMessages.changeNotListed
-          }
-
-          "contains content" which {
-
-            lazy val helpContent = progressiveDisclosure.select("div > p")
-
-            "displays the correct text" in {
-              helpContent.text() shouldEqual viewMessages.helpText
+            "has a registration header" in {
+              elementText("#registration-section > h2") shouldBe viewMessages.registrationStatusHeading
             }
 
-            s"has a link to ${mockConfig.govUkChangeVatRegistrationDetails}" in {
-              helpContent.select("a").attr("href") shouldEqual mockConfig.govUkChangeVatRegistrationDetails
+            "has a registration status header" in {
+              elementText("#registration-status-text") shouldBe viewMessages.statusText
             }
+
+            "displays the correct registration status" in {
+              elementText("#registration-status") shouldBe viewMessages.registeredStatus
+            }
+          }
+
+          "has an about header" in {
+            elementText("#content > article > div:nth-child(2) > h2") shouldBe viewMessages.aboutHeading
+          }
+
+          "have a section for business address" which {
+
+            "has the heading" in {
+              elementText("#businessAddressHeading") shouldBe viewMessages.businessAddressHeading
+            }
+
+            "has the correct address output" in {
+              elementText("#businessAddress li:nth-child(1)") shouldBe customerInformationModelMaxIndividual.ppob.address.line1
+              elementText("#businessAddress li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.ppob.address.line2.get
+              elementText("#businessAddress li:nth-child(3)") shouldBe customerInformationModelMaxIndividual.ppob.address.postCode.get
+            }
+
+            "has a change link" which {
+
+              s"has the wording '${viewMessages.change}'" in {
+                elementText("#place-of-business-status") shouldBe viewMessages.change
+              }
+
+              s"has the correct aria label text '${viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)}'" in {
+                element("#place-of-business-status").attr("aria-label") shouldBe viewMessages.changeBusinessAddressHidden(PPOBAddressTestConstants.addLine1)
+              }
+
+              s"has a link to ${controllers.routes.BusinessAddressController.show().url}" in {
+                element("#place-of-business-status").attr("href") shouldBe controllers.routes.BusinessAddressController.show().url
+              }
+            }
+          }
+
+          "have a section for repayment Bank Account details" which {
+
+            "has the heading" in {
+              elementText("#bank-details-text") shouldBe viewMessages.bankDetailsHeading
+            }
+
+            "has a the correct Account Number" which {
+
+              "has the correct heading for the Account Number" in {
+                elementText("#bank-details li:nth-child(1)") shouldBe viewMessages.accountNumberHeading
+              }
+
+              "has the correct value for the account number" in {
+                elementText("#bank-details li:nth-child(2)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.bankAccountNumber.get
+              }
+            }
+
+            "has a the correct Sort Code" which {
+
+              "has the correct heading for the Sort Code" in {
+                elementText("#bank-details li:nth-child(3)") shouldBe viewMessages.sortcodeHeading
+              }
+
+              "has the correct value for the account number" in {
+                elementText("#bank-details li:nth-child(4)") shouldBe customerInformationModelMaxIndividual.bankDetails.get.sortCode.get
+              }
+            }
+
+            "has a change link" which {
+
+              s"has the wording '${viewMessages.change}'" in {
+                elementText("#bank-details-status") shouldBe viewMessages.change
+              }
+
+              s"has the correct aria label text '${viewMessages.changeBankDetailsHidden}'" in {
+                element("#bank-details-status").attr("aria-label") shouldBe viewMessages.changeBankDetailsHidden
+              }
+
+              s"has a link to ${controllers.routes.PaymentsController.sendToPayments().url}" in {
+                element("#bank-details-status").attr("href") shouldBe controllers.routes.PaymentsController.sendToPayments().url
+              }
+            }
+          }
+
+          "have a section for return frequency" which {
+
+            "has the correct heading" in {
+              elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
+            }
+
+            "has the correct current frequency" in {
+              elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
+            }
+
+            "has a change link" which {
+
+              s"has the wording '${viewMessages.change}'" in {
+                elementText("#vat-return-dates-status") shouldBe viewMessages.change
+              }
+
+              s"has a link to ${controllers.returnFrequency.routes.ChooseDatesController.show().url}" in {
+                element("#vat-return-dates-status").attr("href") shouldBe controllers.returnFrequency.routes.ChooseDatesController.show().url
+              }
+            }
+          }
+
+          "have a section for contact details" which {
+
+            "has a contact details header" in {
+              elementText("#contact-details-section > h2") shouldBe viewMessages.contactDetailsHeading
+            }
+          }
+
+          "have a section for email address" which {
+
+            "has the heading" in {
+              elementText("#vat-email-address-text") shouldBe viewMessages.emailAddressHeading
+            }
+
+            "has the correct value for the email address" in {
+              elementText("#vat-email-address") shouldBe customerInformationModelMaxIndividual.ppob.contactDetails.get.emailAddress.get
+            }
+
+            "has a change link" which {
+
+              s"has the wording '${viewMessages.change}'" in {
+                elementText("#vat-email-address-status") shouldBe viewMessages.change
+              }
+
+              s"has the correct aria label text '${viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)}'" in {
+                element("#vat-email-address-status").attr("aria-label") shouldBe
+                  viewMessages.changeEmailAddressHidden(PPOBAddressTestConstants.email)
+              }
+
+              s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
+                element("#vat-email-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeEmailUrl
+              }
+            }
+          }
+
+          "have a section for phone numbers" which {
+
+            "has the heading" in {
+              elementText("#vat-phone-numbers-text") shouldBe viewMessages.phoneNumbersHeading
+            }
+
+            "has the correct value for the phone numbers" in {
+              elementText("#vat-phone-numbers") shouldBe
+                s"Landline: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.phoneNumber.get} " +
+                  s"Mobile: ${customerInformationModelMaxIndividual.ppob.contactDetails.get.mobileNumber.get}"
+            }
+
+            "has a change link" which {
+
+              s"has the wording '${viewMessages.change}'" in {
+                elementText("#vat-phone-numbers-status") shouldBe viewMessages.change
+              }
+
+              s"has the correct aria label text '${viewMessages.changePhoneNumbersHidden}'" in {
+                element("#vat-phone-numbers-status").attr("aria-label") shouldBe
+                  viewMessages.changePhoneNumbersHidden
+              }
+
+              s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
+                element("#vat-phone-numbers-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangePhoneNumbersUrl
+              }
+            }
+          }
+
+          "have a section for website address" which {
+
+            "has the heading" in {
+              elementText("#vat-website-address-text") shouldBe viewMessages.websiteAddressHeading
+            }
+
+            "has the correct value for the website address" in {
+              elementText("#vat-website-address") shouldBe customerInformationModelMaxIndividual.ppob.websiteAddress.get
+            }
+
+            "has a change link" which {
+
+              s"has the wording '${viewMessages.change}'" in {
+                elementText("#vat-website-address-status") shouldBe viewMessages.change
+              }
+
+              s"has the correct aria label text '${viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)}'" in {
+                element("#vat-website-address-status").attr("aria-label") shouldBe
+                  viewMessages.changeWebsiteAddressHidden(PPOBAddressTestConstants.website)
+              }
+
+              s"has a link to ${mockConfig.vatCorrespondenceChangeEmailUrl}" in {
+                element("#vat-website-address-status").attr("href") shouldBe mockConfig.vatCorrespondenceChangeWebsiteUrl
+              }
+            }
+          }
+
+          "not display the 'change another clients details' link" in {
+            elementExtinct("#change-client-text")
+          }
+
+          "display a progressive disclosure" which {
+
+            "contains help text" which {
+
+              lazy val progressiveDisclosure = element("details")
+
+              "contains the correct text" in {
+                progressiveDisclosure.select("summary").text() shouldEqual viewMessages.changeNotListed
+              }
+
+              "contains content" which {
+
+                lazy val helpContent = progressiveDisclosure.select("div > p")
+
+                "displays the correct text" in {
+                  helpContent.text() shouldEqual viewMessages.helpText
+                }
+
+                s"has a link to ${mockConfig.govUkChangeVatRegistrationDetails}" in {
+                  helpContent.select("a").attr("href") shouldEqual mockConfig.govUkChangeVatRegistrationDetails
+                }
+              }
+            }
+          }
+        }
+
+        "useVatReturnPeriodFrontend feature switch is on" should {
+
+          lazy val view = {
+            mockConfig.features.useVatReturnPeriodFrontend(true)
+            views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
+          }
+
+          lazy implicit val document: Document = Jsoup.parse(view.body)
+
+          "have a section for return frequency" which {
+
+            s"has a change link to ${mockConfig.vatReturnPeriodFrontendUrl}" in {
+              element("#vat-return-dates-status").attr("href") shouldBe mockConfig.vatReturnPeriodFrontendUrl
+            }
+          }
+        }
+      }
+
+      "deregistered for VAT" should {
+
+        lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividualDeregistered)(user, messages, mockConfig)
+        lazy implicit val document: Document = Jsoup.parse(view.body)
+
+        "have a section for registration status" which {
+
+          "has a registration header" in {
+            elementText("#registration-section > h2") shouldBe viewMessages.registrationStatusHeading
+          }
+
+          "has a registration status header" in {
+            elementText("#registration-status-text") shouldBe viewMessages.statusText
+          }
+
+          "displays the correct registration status" in {
+            elementText("#registration-status") shouldBe viewMessages.deregStatus(toLongDate(pastDate))
+          }
+
+          "has the 'how to register' link" in {
+            elementText("#registration-status-link") shouldBe viewMessages.howToRegister
+            element("#registration-status-link").attr("href") shouldBe "https://www.gov.uk/vat-registration/how-to-register"
           }
         }
       }
@@ -762,7 +822,6 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
       }
     }
 
-
     "the registration feature switch is disabled" should {
 
       lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
@@ -770,7 +829,7 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
 
       "not have a registration section" in {
         mockConfig.features.registrationStatus(false)
-        elementText("div.form-group:nth-child(3) > h2:nth-child(1)") shouldBe viewMessages.aboutHeading
+        elementText("div.form-group:nth-child(2) > h2:nth-child(1)") shouldBe viewMessages.aboutHeading
         document.select("#registration-status-text").isEmpty shouldBe true
         document.select("#registration-status").isEmpty shouldBe true
         document.select("#registration-status-link").isEmpty shouldBe true
@@ -822,7 +881,7 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
 
     "the registration status is false - deregistration set to a past date" should {
 
-      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividual)(user, messages, mockConfig)
+      lazy val view = views.html.customerInfo.customer_circumstance_details(customerInformationNoPendingIndividualDeregistered)(user, messages, mockConfig)
       lazy implicit val document: Document = Jsoup.parse(view.body)
 
       "registration section displays the following" in {


### PR DESCRIPTION
- Also refactored CustomerCircumstanceDetailsViewSpec (in a separate, last commit) as the scenarios were unreadable and some were duplicated throughout
- See slack for app config PRs