### PR TITLE
BTAT-7378: Replaced ability to opt out with sign up for NonDigital users

### DIFF
--- a/app/views/helpers/MtdSectionHelper.scala.html
+++ b/app/views/helpers/MtdSectionHelper.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import models.circumstanceInfo.CircumstanceDetails
-@import models.circumstanceInfo.NonMTDfB
+@import models.circumstanceInfo.{NonMTDfB, NonDigital}
 
 @this()
 
@@ -27,7 +27,9 @@
   </dt>
   <dd id="opt-in" class="cya-answer">
     @(circumstances.mandationStatus, circumstances.pendingMandationStatus) match {
-      case (_, Some(NonMTDfB)) | (NonMTDfB, None) => { @messages("customer_details.makingTaxDigital.optedOut") }
+      case (_, Some(NonMTDfB)) | (NonMTDfB, None) | (NonDigital, None) => {
+        @messages("customer_details.makingTaxDigital.optedOut")
+      }
       case _ => { @messages("customer_details.makingTaxDigital.optedIn") }
     }
   </dd>
@@ -40,7 +42,7 @@
           @messages("customer_details.pending")
         </span>
       }
-      case None if circumstances.mandationStatus == NonMTDfB => {
+      case None if (circumstances.mandationStatus == NonMTDfB | circumstances.mandationStatus == NonDigital) => {
         <a id="opt-in-status"
            href="@appConfig.mtdSignUpUrl(vrn)"
            aria-label="@messages("customer_details.makingTaxDigital.optOutChange.hidden")">

--- a/test/assets/CircumstanceDetailsTestConstants.scala
+++ b/test/assets/CircumstanceDetailsTestConstants.scala
@@ -457,6 +457,7 @@ object CircumstanceDetailsTestConstants {
   )
 
   val customerInformationNonMtd: CircumstanceDetails = customerInformationModelMin.copy(mandationStatus = NonMTDfB)
+  val customerInformationNonDigital: CircumstanceDetails = customerInformationModelMin.copy(mandationStatus = NonDigital)
   val customerInformationPendingOptOut: CircumstanceDetails = customerInformationModelMin.copy(
     pendingChanges = Some(PendingChanges(None, None, None, Some(NonMTDfB)))
   )

--- a/test/views/helpers/MakingTaxDigitalSectionSpec.scala
+++ b/test/views/helpers/MakingTaxDigitalSectionSpec.scala
@@ -90,6 +90,31 @@ class MakingTaxDigitalSectionSpec extends ViewBaseSpec {
       }
     }
 
+    "the user's client has a NonDigital mandation status" should {
+
+      lazy val view = injectedView(customerInformationNonDigital, vrn)
+      lazy implicit val document: Document = Jsoup.parse(view.body)
+
+      "have the correct row title" in {
+        elementText("#opt-in-text") shouldBe "Status"
+      }
+
+      "have the correct value" in {
+        elementText("#opt-in") shouldBe "Opted out"
+      }
+
+      "have a link" which {
+
+        "has the correct link text" in {
+          elementText("#opt-in-status") shouldBe "Sign up"
+        }
+
+        "has the correct link location" in {
+          element("#opt-in-status").attr("href") shouldBe mockConfig.mtdSignUpUrl(vrn)
+        }
+      }
+    }
+
     "the user's client is opted in to MTD" should {
 
       lazy val view = injectedView(customerInformationModelMin, vrn)


### PR DESCRIPTION
# Pull Request Checklist
* [x] Branch is rebased with master
* [x] Added Unit Tests for changed functionality
* [x] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [ ] Ran Acceptance tests as per the story. If any query ping in group slack and confirm the AT's repo
* [ ] Ran Performance tests as per the story. If any query ping in group slack and confirm the PT's repo
* [ ] (If applicable) raised app-config-* PRs
* [ ] (If applicable) ran Wave test for changes to views
* [ ] (If applicable) added Integration Test
