### PR TITLE
BTAT-8449 Added info panel when return dates are pending

### DIFF
--- a/app/views/customerInfo/CustomerCircumstanceDetailsView.scala.html
+++ b/app/views/customerInfo/CustomerCircumstanceDetailsView.scala.html
@@ -364,19 +364,20 @@ addStatusRowHelper: AddStatusRowHelper, breadcrumb: Breadcrumb, openInNewTab: Op
         </dl>
     </div>
 
-    @if(circumstances.returnPeriod.isDefined){
-        <div id="return-details-section" class="form-group">
+    @circumstances.returnPeriod.map { period =>
+
+      @if(circumstances.pendingReturnPeriod.isDefined) {
+        <div class="panel panel-border-wide">
+          @messages("customer_details.returnFrequency.newDates")
+        </div>
+      }
+
+      <div id="return-details-section" class="form-group">
         <h2 class="heading-medium">@messages("customer_details.returnFrequencySection.heading")</h2>
         <dl class="govuk-check-your-answers cya-questions-short">
-            @circumstances.pendingReturnPeriod.fold {
-            @circumstances.returnPeriod.map { period =>
-            @customerReturnPeriod(period, false)
-            }
-            }{ pendingPeriod =>
-            @customerReturnPeriod(pendingPeriod, true)
-            }
+          @customerReturnPeriod(period, pending = circumstances.pendingReturnPeriod.isDefined)
         </dl>
-        </div>
+      </div>
     }
 
         <div id="contact-details-section" class="form-group">

--- a/conf/messages
+++ b/conf/messages
@@ -96,6 +96,7 @@ customer_details.returnFrequencySection.heading = Return details
 customer_details.returnFrequency.heading = VAT Return dates
 customer_details.returnFrequency.change.hidden = Change the VAT Return dates from {0}
 customer_details.returnFrequency.pending.hidden = Change to VAT Return dates is pending
+customer_details.returnFrequency.newDates = You have asked to change the VAT Return dates. The new dates will be shown when the change has been applied to this account.
 customer_details.contactDetails.heading = Contact details
 customer_details.contactDetails.emailAddress = Email address
 customer_details.contactDetails.emailAddress.change.hidden = Change the business email address from {0}

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -99,6 +99,7 @@ customer_details.returnFrequencySection.heading = Manylion y Ffurflen TAW
 customer_details.returnFrequency.heading = Dyddiadau cyflwyno Ffurflenni TAW
 customer_details.returnFrequency.change.hidden = Newid dyddiadau’r Ffurflenni TAW o {0}
 customer_details.returnFrequency.pending.hidden = Mae’r newid i ddyddiadau’r Ffurflenni TAW ar y gweill
+customer_details.returnFrequency.newDates = Rydych wedi gofyn am gael newid y dyddiadau ar gyfer Ffurflenni TAW. Bydd y dyddiad newydd yn cael ei ddangos pan fydd y newid wedi’i wneud i’r cyfrif hwn.
 customer_details.contactDetails.heading = Manylion cyswllt
 customer_details.contactDetails.emailAddress = Cyfeiriad e-bost
 customer_details.contactDetails.emailAddress.change.hidden = Newid cyfeiriad e-bost y busnes o {0}

--- a/test/assets/CircumstanceDetailsTestConstants.scala
+++ b/test/assets/CircumstanceDetailsTestConstants.scala
@@ -461,109 +461,12 @@ object CircumstanceDetailsTestConstants {
     ))
   )
 
-  val overseasCompany: CircumstanceDetails = customerInformationModelMin.copy(customerDetails = organisation.copy(overseasIndicator = true))
+  val customerInformationPendingReturnPeriodModel: CircumstanceDetails = customerInformationRegisteredIndividual.copy(
+    pendingChanges = Some(PendingChanges(
+      None, None, Some(Monthly)
+    ))
+  )
 
-  /////////////// Release 8 data -- separated for ease of removal
-
-//  val customerInformationModelMaxOrganisationR8: CircumstanceDetails = CircumstanceDetails(
-//    customerDetails = organisationR8,
-//    flatRateScheme = Some(frsModelMax),
-//    ppob = ppobModelMax,
-//    bankDetails = Some(bankDetailsModelMax),
-//    returnPeriod = Some(Mar),
-//    deregistration = Some(deregModel),
-//    missingTrader = true,
-//    changeIndicators = Some(ChangeIndicators(
-//      ppob = true,
-//      bankDetails = true,
-//      returnPeriod = true,
-//      deregister = true
-//    )),
-//    pendingChanges = Some(PendingChanges(
-//      ppob = Some(ppobModelMax),
-//      bankDetails = Some(bankDetailsModelMax),
-//      returnPeriod = Some(Mar)
-//    )),
-//    partyType = Some(partyType)
-//  )
-//
-//  val customerInformationModelMinR8: CircumstanceDetails = CircumstanceDetails(
-//    customerDetails = CustomerDetails(
-//      firstName = None,
-//      lastName = None,
-//      organisationName = None,
-//      tradingName = None,
-//      welshIndicator = None,
-//      overseasIndicator = false),
-//    flatRateScheme = None,
-//    ppob = ppobModelMin,
-//    bankDetails = None,
-//    returnPeriod = None,
-//    deregistration = None,
-//    missingTrader = false,
-//    changeIndicators = None,
-//    pendingChanges = None,
-//    partyType = None
-//  )
-//
-//  val customerInformationJsonMaxOrganisationR8: JsValue = Json.obj(
-//    "customerDetails" -> organisationJsonR8,
-//    "flatRateScheme" -> frsJsonMax,
-//    "ppob" -> ppobJsonMax,
-//    "bankDetails" -> bankDetailsJsonMax,
-//    "returnPeriod" -> returnPeriodMCJson,
-//    "partyType" -> Some(partyType),
-//    "deregistration" -> deregModel,
-//    "missingTrader" -> true,
-//    "changeIndicators" -> Json.obj(
-//      "PPOBDetails" -> true,
-//      "bankDetails" -> true,
-//      "returnPeriod" -> true,
-//      "deregister" -> true
-//    ),
-//    "pendingChanges" -> Json.obj(
-//      "PPOBDetails" -> Json.obj(
-//        "address" -> Json.obj(
-//          "line1" -> addLine1,
-//          "line2" -> addLine2,
-//          "line3" -> addLine3,
-//          "line4" -> addLine4,
-//          "line5" -> addLine5,
-//          "postCode" -> postcode,
-//          "countryCode" -> countryCode
-//        ),
-//        "contactDetails" -> Json.obj(
-//          "primaryPhoneNumber" -> phoneNumber,
-//          "mobileNumber" -> mobileNumber,
-//          "faxNumber" -> faxNumber,
-//          "emailAddress" -> email,
-//          "emailVerified" -> emailVerified
-//        ),
-//        "websiteAddress" -> website
-//      ),
-//      "bankDetails" -> Json.obj(
-//        "accountHolderName" -> accName,
-//        "bankAccountNumber" -> accNum,
-//        "sortCode" -> accSort
-//      ),
-//      "returnPeriod" -> returnPeriodMCJson
-//    )
-//  )
-//
-//  val customerInformationJsonMinR8: JsValue =
-//    Json.obj(
-//      "customerDetails" -> customerDetailsJsonMinR8,
-//      "ppob" -> ppobJsonMin,
-//      "missingTrader" -> false
-//    )
-//
-//  val customerInformationJsonMinWithTrueOverseas: JsValue =
-//    Json.obj(
-//      "customerDetails" -> Json.obj(
-//        "hasFlatRateScheme" -> false,
-//        "overseasIndicator" -> true
-//      ),
-//      "ppob" -> ppobJsonMin,
-//      "missingTrader" -> false
-//  )
+  val overseasCompany: CircumstanceDetails =
+    customerInformationModelMin.copy(customerDetails = organisation.copy(overseasIndicator = true))
 }

--- a/test/assets/messages/CustomerCircumstanceDetailsPageMessages.scala
+++ b/test/assets/messages/CustomerCircumstanceDetailsPageMessages.scala
@@ -67,6 +67,10 @@ object CustomerCircumstanceDetailsPageMessages extends BaseMessages {
   val newChangeClientDetails = "Change client"
   val deregText: String => String = date => s"VAT registration cancelled on on $date"
   val changeNotListed: String = "The change I want to make is not listed"
-  val helpText: String = "You can make any other changes (opens in a new tab) using a form. You must print and complete this form before posting it to HMRC."
+  val helpText: String = "You can make any other changes (opens in a new tab) using a form. " +
+    "You must print and complete this form before posting it to HMRC."
   val backText: String = "Back"
+
+  val newReturnDatesApplied: String = "You have asked to change the VAT Return dates. " +
+    "The new dates will be shown when the change has been applied to this account."
 }

--- a/test/views/customerInfo/CustomerCircumstanceDetailsViewSpec.scala
+++ b/test/views/customerInfo/CustomerCircumstanceDetailsViewSpec.scala
@@ -326,31 +326,28 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
 
         "with pending changes" when {
 
-          "deregistering" when {
+          "deregistration is pending" should {
 
-            "deregistration is still pending" should {
+            lazy val view = injectedView(customerInformationModelDeregPending, getPartialHtmlNotAgent)(user, messages, mockConfig)
+            lazy implicit val document: Document = Jsoup.parse(view.body)
 
-              lazy val view = injectedView(customerInformationModelDeregPending, getPartialHtmlNotAgent)(user, messages, mockConfig)
-              lazy implicit val document: Document = Jsoup.parse(view.body)
+            "have a section for return frequency" which {
 
-              "have a section for return frequency" which {
+              "has the heading" in {
+                elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
+              }
 
-                "has the heading" in {
-                  elementText("#vat-return-dates-text") shouldBe viewMessages.returnFrequencyHeading
-                }
+              "has the correct value output for the current frequency" in {
+                elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
+              }
 
-                "has the correct value output for the current frequency" in {
-                  elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
-                }
-
-                "has no change link or pending status" in {
-                  document.select("#vat-return-dates-status").isEmpty shouldBe true
-                }
+              "has no change link or pending status" in {
+                document.select("#vat-return-dates-status").isEmpty shouldBe true
               }
             }
           }
 
-          "with pending PPOB" should {
+          "PPOB is pending" should {
 
             lazy val view = injectedView(customerInformationPendingPPOBModel, getPartialHtmlNotAgent)(user, messages, mockConfig)
             lazy implicit val document: Document = Jsoup.parse(view.body)
@@ -365,21 +362,40 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
             }
           }
 
-          "with pending Website" when {
+          "website is pending" should {
 
-            "the website has been changed" should {
+            lazy val view = injectedView(customerInformationPendingWebsiteModel, getPartialHtmlNotAgent)(user, messages, mockConfig)
+            lazy implicit val document: Document = Jsoup.parse(view.body)
 
-              lazy val view = injectedView(customerInformationPendingWebsiteModel, getPartialHtmlNotAgent)(user, messages, mockConfig)
-              lazy implicit val document: Document = Jsoup.parse(view.body)
+            s"have link text of '${viewMessages.pending}'" in {
+              elementText("#vat-website-address-status") shouldBe viewMessages.pending
+            }
 
-              s"have link text of '${viewMessages.pending}'" in {
-                elementText("#vat-website-address-status") shouldBe viewMessages.pending
-              }
+            s"have the correct aria label text '${viewMessages.pendingWebsiteAddressHidden}'" in {
+              element("#vat-website-address-status").attr("aria-label") shouldBe
+                viewMessages.pendingWebsiteAddressHidden
+            }
+          }
 
-              s"have the correct aria label text '${viewMessages.pendingWebsiteAddressHidden}'" in {
-                element("#vat-website-address-status").attr("aria-label") shouldBe
-                  viewMessages.pendingWebsiteAddressHidden
-              }
+          "return frequency is pending" should {
+
+            lazy val view = injectedView(customerInformationPendingReturnPeriodModel, getPartialHtmlNotAgent)(user, messages, mockConfig)
+            lazy implicit val document: Document = Jsoup.parse(view.body)
+
+            s"have link text of '${viewMessages.pending}'" in {
+              elementText("#vat-return-dates-status") shouldBe viewMessages.pending
+            }
+
+            s"have the correct aria label text '${viewMessages.pendingReturnFrequencyHidden}'" in {
+              element("#vat-return-dates-status").attr("aria-label") shouldBe viewMessages.pendingReturnFrequencyHidden
+            }
+
+            "display the existing approved return dates" in {
+              elementText("#vat-return-dates") shouldBe ReturnFrequencyMessages.option3Mar
+            }
+
+            "display a panel with information regarding when the new dates will be applied" in {
+              elementText(".panel-border-wide") shouldBe viewMessages.newReturnDatesApplied
             }
           }
 
@@ -397,9 +413,7 @@ class CustomerCircumstanceDetailsViewSpec extends ViewBaseSpec with BaseMessages
                 viewMessages.pendingWebsiteAddressHidden
             }
           }
-
         }
-
       }
 
       "with no website" should {


### PR DESCRIPTION
There has also been a small logic change in line with the new content, which means that only the approved stagger dates will be shown on the ChoC overview page.

# Pull Request Checklist
* [x] Branch is rebased with master
* [x] Added Unit Tests for changed functionality
* [x] Ran `sbt clean compile coverage test it:test coverageReport`, all tests pass and coverage meets minimum
* [ ] Checked libraries are up to date with `sbt validate`. (If applicable) library updates are done in a separate, single commit
* [x] Ran Acceptance tests as per the story. If any query ping in group slack and confirm the AT's repo
