### PR TITLE
BTAT-8588 Update trading name handoff URL

### DIFF
--- a/app/connectors/ServiceInfoPartialConnector.scala
+++ b/app/connectors/ServiceInfoPartialConnector.scala
@@ -26,10 +26,12 @@ import uk.gov.hmrc.http.HttpClient
 import uk.gov.hmrc.play.partials.HtmlPartial
 import uk.gov.hmrc.play.partials.HtmlPartial._
 import scala.concurrent.{ExecutionContext, Future}
+import views.html.templates.BTANavigationLinks
 
 @Singleton
 class ServiceInfoPartialConnector @Inject()(val http: HttpClient,
-                                            hcForPartials: VatcHeaderCarrierForPartialsConverter)
+                                            hcForPartials: VatcHeaderCarrierForPartialsConverter,
+                                            btaNavigationLinks: BTANavigationLinks)
                                            (implicit val messagesApi: MessagesApi,
                                             val config: AppConfig) extends HtmlPartialHttpReads with I18nSupport {
   import hcForPartials._
@@ -37,10 +39,10 @@ class ServiceInfoPartialConnector @Inject()(val http: HttpClient,
   def getServiceInfoPartial()(implicit request: Request[_], executionContext: ExecutionContext): Future[Html] =
     http.GET[HtmlPartial](config.btaPartialUrl) recover connectionExceptionsAsHtmlPartialFailure map {
       p =>
-        p.successfulContentOrElse(views.html.templates.btaNavigationLinks())
+        p.successfulContentOrElse(btaNavigationLinks())
     } recover {
       case _ =>
         Logger.warn(s"[ServiceInfoPartialConnector][getServiceInfoPartial] - Unexpected error retrieving BTA partial")
-        views.html.templates.btaNavigationLinks()
+        btaNavigationLinks()
     }
 }

--- a/app/views/templates/BTANavigationLinks.scala.html
+++ b/app/views/templates/BTANavigationLinks.scala.html
@@ -14,6 +14,8 @@
  * limitations under the License.
  *@
 
+@this()
+
 @()(implicit messages: Messages, appConfig: config.AppConfig)
 
 <nav class="centered-content bta-navigation" >

--- a/build.sbt
+++ b/build.sbt
@@ -58,10 +58,10 @@ lazy val coverageSettings: Seq[Setting[_]] = {
 
 val compile: Seq[ModuleID] = Seq(
   ws,
-  "uk.gov.hmrc"       %% "bootstrap-frontend-play-26" % "2.25.0",
-  "uk.gov.hmrc"       %% "play-partials"              % "6.11.0-play-26",
-  "uk.gov.hmrc"       %% "govuk-template"             % "5.57.0-play-26",
-  "uk.gov.hmrc"       %% "play-ui"                    % "8.12.0-play-26",
+  "uk.gov.hmrc"       %% "bootstrap-frontend-play-26" % "3.0.0",
+  "uk.gov.hmrc"       %% "play-partials"              % "7.0.0-play-26",
+  "uk.gov.hmrc"       %% "govuk-template"             % "5.58.0-play-26",
+  "uk.gov.hmrc"       %% "play-ui"                    % "8.13.0-play-26",
   "org.typelevel"     %% "cats"                       % "0.9.0",
   "uk.gov.hmrc"       %% "play-language"              % "4.4.0-play-26",
   "com.typesafe.play" %% "play-json-joda"             % "2.6.14"
@@ -90,7 +90,7 @@ def oneForkedJvmPerTest(tests: Seq[TestDefinition]): Seq[Group] = tests map {
 
 lazy val microservice: Project = Project(appName, file("."))
   .disablePlugins(JUnitXmlReportPlugin)
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*)
+  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin) ++ plugins: _*)
   .settings(PlayKeys.playDefaultPort := 9150)
   .settings(coverageSettings: _*)
   .settings(playSettings: _*)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -228,7 +228,7 @@ vat-return-period-frontend {
 }
 
 vat-designatory-details-frontend {
-  newTradingNameUrl = "http://localhost:9165/vat-through-software/account/designatory/new-trading-name"
+  newTradingNameUrl = "http://localhost:9165/vat-through-software/account/designatory/change-remove-trading-name"
 }
 
 tracking-consent-frontend {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -26,7 +26,7 @@ play.modules.enabled += "uk.gov.hmrc.play.bootstrap.graphite.GraphiteMetricsModu
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
-play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.frontend.FrontendModule"
 play.modules.enabled += "config.DIModule"
 
 # Application Loader

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,8 +10,6 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
-addSbtPlugin("uk.gov.hmrc" %  "sbt-artifactory" % "1.6.0")
-
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")

--- a/test/views/templates/BtaNavigationLinksTemplateSpec.scala
+++ b/test/views/templates/BtaNavigationLinksTemplateSpec.scala
@@ -19,9 +19,11 @@ package views.templates
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.twirl.api.Html
+import views.html.templates.BTANavigationLinks
 
 class BtaNavigationLinksTemplateSpec extends TemplateBaseSpec {
 
+  val injectedView: BTANavigationLinks = inject[BTANavigationLinks]
   val btaHome = "Home"
   val btaMessages = "Messages"
   val btaManageAccount = "Manage account"
@@ -29,7 +31,7 @@ class BtaNavigationLinksTemplateSpec extends TemplateBaseSpec {
 
   "btaNavigationLinks" should {
 
-    val view: Html = views.html.templates.btaNavigationLinks()(messages,mockConfig)
+    val view: Html = injectedView()(messages,mockConfig)
     lazy implicit val document: Document = Jsoup.parse(view.body)
 
 
@@ -44,7 +46,6 @@ class BtaNavigationLinksTemplateSpec extends TemplateBaseSpec {
       "should have a link to home" in {
         homeLink.attr("href") shouldBe mockConfig.btaHomeUrl
       }
-
     }
 
     "have a link to BTA Manage Account" which {
@@ -58,7 +59,6 @@ class BtaNavigationLinksTemplateSpec extends TemplateBaseSpec {
       "should have a link to Manage account" in {
         manageAccountLink.attr("href") shouldBe mockConfig.btaManageAccountUrl
       }
-
     }
 
     "have a link to BTA Messages" which {
@@ -72,7 +72,6 @@ class BtaNavigationLinksTemplateSpec extends TemplateBaseSpec {
       "should have a link to Messages" in {
         messagesLink.attr("href") shouldBe mockConfig.btaMessagesUrl
       }
-
     }
 
     "have a link to BTA Help and contact" which {
@@ -86,10 +85,6 @@ class BtaNavigationLinksTemplateSpec extends TemplateBaseSpec {
       "should have a link to Help and contact" in {
         helpAndContactLink.attr("href") shouldBe mockConfig.btaHelpAndContactUrl
       }
-
     }
-
   }
 }
-
-


### PR DESCRIPTION
This cannot be merged until the routing is complete for the new URL so that the "add" journey still works as normal to allow the acceptance tests to pass.

As part of the dependency update I have also:
- removed the `sbt-artifactory` plugin, as the newest version was giving an error. Threads on Slack state this plugin is now in Jenkins by default and is no longer needed in each service.
- refactored `BTANavigationLinks` to use DI which looks to have been missed as part of the Play 2.6 upgrade

Please also merge: https://github.com/hmrc/app-config-base/pull/4472