### PR TITLE
BTAT-8716 Added new valid party types and routing for R19 business name change

### DIFF
--- a/app/config/ConfigKeys.scala
+++ b/app/config/ConfigKeys.scala
@@ -54,6 +54,7 @@ object ConfigKeys {
   val govUkSetupAgentServices: String = "gov-uk.guidance.setupAgentServices.url"
 
   val partyTypes: String = "party-types"
+  val partyTypesR19: String = "party-types-r19"
 
   val governmentGatewayHost: String = "government-gateway.host"
 
@@ -81,6 +82,7 @@ object ConfigKeys {
   val vatCorrespondenceVerificationEmail: String = "vat-correspondence-details-frontend.sendVerificationEmail"
 
   val vatDesignatoryDetailsNewTradingNameUrl: String = "vat-designatory-details-frontend.newTradingNameUrl"
+  val vatDesignatoryDetailsNewBusinessNameUrl: String = "vat-designatory-details-frontend.newBusinessNameUrl"
 
   val vatAgentClientLookupFrontendHost: String = "vat-agent-client-lookup-frontend.host"
   val vatAgentClientLookupFrontendUrl: String = "vat-agent-client-lookup-frontend.url"

--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -61,7 +61,8 @@ trait AppConfig {
   val vatCorrespondenceChangeWebsiteUrl: String
   val vatCorrespondenceSendVerificationEmail: String
   val vatDesignatoryDetailsTradingNameUrl: String
-  val partyTypes: Seq[String]
+  val vatDesignatoryDetailsBusinessNameUrl: String
+  def partyTypes: Seq[String]
   val govUkChangeVatRegistrationDetails: String
   val govUkSoftwareGuidanceUrl: String
   val govUkVat484Form: String
@@ -176,9 +177,13 @@ class FrontendAppConfig @Inject()(implicit configuration: Configuration, service
   override lazy val vatCorrespondenceChangeWebsiteUrl: String = servicesConfig.getString(Keys.vatCorrespondenceChangeWebsiteUrl)
   override lazy val vatCorrespondenceSendVerificationEmail: String = servicesConfig.getString(Keys.vatCorrespondenceVerificationEmail)
 
-  override lazy val vatDesignatoryDetailsTradingNameUrl: String = servicesConfig.getString(Keys.vatDesignatoryDetailsNewTradingNameUrl)
+  override lazy val vatDesignatoryDetailsTradingNameUrl: String =
+    servicesConfig.getString(Keys.vatDesignatoryDetailsNewTradingNameUrl)
+  override lazy val vatDesignatoryDetailsBusinessNameUrl: String =
+    servicesConfig.getString(Keys.vatDesignatoryDetailsNewBusinessNameUrl)
 
-  override lazy val partyTypes: Seq[String] = getStringSeq(Keys.partyTypes)
+  override def partyTypes: Seq[String] =
+    if(features.organisationNameRowEnabled()) getStringSeq(Keys.partyTypesR19) else getStringSeq(Keys.partyTypes)
 
   override lazy val govUkChangeVatRegistrationDetails: String = servicesConfig.getString(Keys.changeVatRegistrationDetails)
 

--- a/app/models/circumstanceInfo/CustomerDetails.scala
+++ b/app/models/circumstanceInfo/CustomerDetails.scala
@@ -26,7 +26,8 @@ case class CustomerDetails(firstName: Option[String],
                            tradingName: Option[String],
                            welshIndicator: Option[Boolean],
                            hasFlatRateScheme: Boolean = false,
-                           overseasIndicator: Boolean) {
+                           overseasIndicator: Boolean,
+                           nameIsReadOnly: Option[Boolean]) {
 
   val isOrg: Boolean = organisationName.isDefined
   val isInd: Boolean = firstName.isDefined || lastName.isDefined
@@ -47,6 +48,7 @@ object CustomerDetails extends JsonReadUtil with JsonObjectSugar {
   private val hasFrsPath = __ \ "hasFlatRateScheme"
   private val welshIndicatorPath = __ \ "welshIndicator"
   private val overseasIndicatorPath = __ \ "overseasIndicator"
+  private val nameIsReadOnlyPath = __ \ "nameIsReadOnly"
 
   implicit val reads: Boolean => Reads[CustomerDetails] = isRelease10 =>
     if(isRelease10) {
@@ -58,6 +60,7 @@ object CustomerDetails extends JsonReadUtil with JsonObjectSugar {
         welshIndicator <- welshIndicatorPath.readOpt[Boolean]
         hasFlatRateScheme <- hasFrsPath.read[Boolean]
         overseasIndicator <- overseasIndicatorPath.read[Boolean]
+        nameIsReadOnly <- nameIsReadOnlyPath.readNullable[Boolean]
       } yield CustomerDetails(
         firstName,
         lastname,
@@ -65,7 +68,8 @@ object CustomerDetails extends JsonReadUtil with JsonObjectSugar {
         tradingName,
         welshIndicator,
         hasFlatRateScheme,
-        overseasIndicator
+        overseasIndicator,
+        nameIsReadOnly
       )
     } else {
       for {
@@ -75,6 +79,7 @@ object CustomerDetails extends JsonReadUtil with JsonObjectSugar {
         tradingName <- tradingNamePath.readOpt[String]
         welshIndicator <- welshIndicatorPath.readOpt[Boolean]
         hasFlatRateScheme <- hasFrsPath.read[Boolean]
+        nameIsReadOnly <- nameIsReadOnlyPath.readNullable[Boolean]
       } yield CustomerDetails(
         firstName,
         lastname,
@@ -82,7 +87,8 @@ object CustomerDetails extends JsonReadUtil with JsonObjectSugar {
         tradingName,
         welshIndicator,
         hasFlatRateScheme,
-        overseasIndicator = false
+        overseasIndicator = false,
+        nameIsReadOnly
       )
     }
 
@@ -94,7 +100,8 @@ object CustomerDetails extends JsonReadUtil with JsonObjectSugar {
         "organisationName" -> model.organisationName,
         "tradingName" -> model.tradingName,
         "welshIndicator" -> model.welshIndicator,
-        "hasFlatRateScheme" -> model.hasFlatRateScheme
+        "hasFlatRateScheme" -> model.hasFlatRateScheme,
+        "nameIsReadOnly" -> model.nameIsReadOnly
       ) ++ (if(isRelease10) Json.obj("overseasIndicator" -> model.overseasIndicator) else Json.obj())
   }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -150,6 +150,7 @@ auditing {
 }
 
 party-types = ["7","50"]
+party-types-r19 = ["Z1","1","2","3","4","5","6","7","8","9","10","50","51","52","53","54","55","58","59","60","61","62","63"]
 
 assets {
   version = "3.11.0"
@@ -230,6 +231,7 @@ vat-return-period-frontend {
 
 vat-designatory-details-frontend {
   newTradingNameUrl = "http://localhost:9165/vat-through-software/account/designatory/change-remove-trading-name"
+  newBusinessNameUrl = "http://localhost:9165/vat-through-software/account/designatory/change-business-name"
 }
 
 tracking-consent-frontend {

--- a/it/helpers/IntegrationTestConstants.scala
+++ b/it/helpers/IntegrationTestConstants.scala
@@ -44,7 +44,8 @@ object IntegrationTestConstants {
     tradingName = Some("Vatmobile Taxi"),
     organisationName = Some("Vatmobile Taxi LTD"),
     welshIndicator = None,
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = Some(false)
   )
 
   val individual: CustomerDetails = CustomerDetails(
@@ -53,7 +54,8 @@ object IntegrationTestConstants {
     tradingName = Some("Vatmobile Taxi"),
     organisationName = None,
     welshIndicator = None,
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = Some(true)
   )
 
   val contactDetailsModelMax: ContactDetails = ContactDetails(

--- a/it/pages/BusinessAddressControllerISpec.scala
+++ b/it/pages/BusinessAddressControllerISpec.scala
@@ -162,7 +162,7 @@ class BusinessAddressControllerISpec extends BasePageISpec {
   "Calling BusinessAddressController.callback" when {
 
     val customerInformationModelMin: CircumstanceDetails = CircumstanceDetails(
-      customerDetails = CustomerDetails(None, None, None, None, None, overseasIndicator = false),
+      customerDetails = CustomerDetails(None, None, None, None, None, overseasIndicator = false, nameIsReadOnly = None),
       flatRateScheme = None,
       ppob = PPOB(
         address = PPOBAddress(

--- a/test/assets/CircumstanceDetailsTestConstants.scala
+++ b/test/assets/CircumstanceDetailsTestConstants.scala
@@ -367,13 +367,7 @@ object CircumstanceDetailsTestConstants {
   )
 
   val customerInformationModelMin: CircumstanceDetails = CircumstanceDetails(
-    customerDetails = CustomerDetails(
-      firstName = None,
-      lastName = None,
-      organisationName = None,
-      tradingName = None,
-      welshIndicator = None,
-      overseasIndicator = false),
+    customerDetails = customerDetailsMin,
     flatRateScheme = None,
     ppob = ppobModelMin,
     bankDetails = None,
@@ -481,6 +475,5 @@ object CircumstanceDetailsTestConstants {
     pendingChanges = Some(PendingChanges(None, None, None, Some("Party Kitchen")))
   )
 
-  val overseasCompany: CircumstanceDetails =
-    customerInformationModelMin.copy(customerDetails = organisation.copy(overseasIndicator = true))
+  val overseasCompany: CircumstanceDetails = customerInformationModelMin.copy(customerDetails = overseasOrganisation)
 }

--- a/test/assets/CustomerDetailsTestConstants.scala
+++ b/test/assets/CustomerDetailsTestConstants.scala
@@ -30,14 +30,16 @@ object CustomerDetailsTestConstants {
     "firstName" -> firstName,
     "lastName" -> lastName,
     "hasFlatRateScheme" -> false,
-    "overseasIndicator" -> false
+    "overseasIndicator" -> false,
+    "nameIsReadOnly" -> false
   )
 
   val organisationJson: JsObject = Json.obj(
     "organisationName" -> orgName,
     "tradingName" -> tradingName,
     "hasFlatRateScheme" -> false,
-    "overseasIndicator" -> false
+    "overseasIndicator" -> false,
+    "nameIsReadOnly" -> false
   )
 
   val customerDetailsJsonMax: JsObject = Json.obj(
@@ -47,7 +49,8 @@ object CustomerDetailsTestConstants {
     "tradingName" -> tradingName,
     "hasFlatRateScheme" -> false,
     "welshIndicator" -> false,
-    "overseasIndicator" -> false
+    "overseasIndicator" -> false,
+    "nameIsReadOnly" -> false
   )
 
   val customerDetailsJsonMin: JsObject = Json.obj(
@@ -55,52 +58,59 @@ object CustomerDetailsTestConstants {
     "overseasIndicator" -> false
   )
 
-  val individual = CustomerDetails(
-      firstName = Some(firstName),
-      lastName = Some(lastName),
-      organisationName = None,
-      tradingName = None,
-      welshIndicator = None,
-      overseasIndicator = false
+  val individual: CustomerDetails = CustomerDetails(
+    firstName = Some(firstName),
+    lastName = Some(lastName),
+    organisationName = None,
+    tradingName = None,
+    welshIndicator = None,
+    overseasIndicator = false,
+    nameIsReadOnly = Some(false)
   )
 
-  val organisation = CustomerDetails(
+  val organisation: CustomerDetails = CustomerDetails(
     firstName = None,
     lastName = None,
     organisationName = Some(orgName),
     tradingName = Some(tradingName),
     welshIndicator = None,
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = Some(false)
   )
 
-  val customerDetailsMax = CustomerDetails(
+  val overseasOrganisation: CustomerDetails = organisation.copy(overseasIndicator = true)
+
+  val customerDetailsMax: CustomerDetails = CustomerDetails(
     Some(firstName),
     Some(lastName),
     Some(orgName),
     Some(tradingName),
     Some(false),
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = Some(false)
   )
 
-  val customerDetailsMin = CustomerDetails(
+  val customerDetailsMin: CustomerDetails = CustomerDetails(
     None,
     None,
     None,
     None,
     None,
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = None
   )
 
 
   ///////////////// Release 8 data -- separated for ease of removal
 
-  val organisationR8 = CustomerDetails(
+  val organisationR8: CustomerDetails = CustomerDetails(
     firstName = None,
     lastName = None,
     organisationName = Some(orgName),
     tradingName = Some(tradingName),
     welshIndicator = None,
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = Some(false)
   )
 
   val organisationJsonR8: JsObject = Json.obj(
@@ -113,24 +123,24 @@ object CustomerDetailsTestConstants {
     "hasFlatRateScheme" -> false
   )
 
-
-
-  val customerDetailsMaxR8 = CustomerDetails(
+  val customerDetailsMaxR8: CustomerDetails = CustomerDetails(
     Some(firstName),
     Some(lastName),
     Some(orgName),
     Some(tradingName),
     Some(false),
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = Some(false)
   )
 
-  val customerDetailsMinR8 = CustomerDetails(
+  val customerDetailsMinR8: CustomerDetails = CustomerDetails(
     None,
     None,
     None,
     None,
     None,
-    overseasIndicator = false
+    overseasIndicator = false,
+    nameIsReadOnly = None
   )
 
   val customerDetailsJsonMaxR8: JsObject = Json.obj(
@@ -139,7 +149,8 @@ object CustomerDetailsTestConstants {
     "lastName" -> lastName,
     "tradingName" -> tradingName,
     "hasFlatRateScheme" -> false,
-    "welshIndicator" -> false
+    "welshIndicator" -> false,
+    "nameIsReadOnly" -> false
   )
 
   val customerDetailsJsonMinWithTrueOverseas: JsObject = Json.obj(

--- a/test/mocks/MockAppConfig.scala
+++ b/test/mocks/MockAppConfig.scala
@@ -62,7 +62,8 @@ class MockAppConfig(implicit val runModeConfiguration: Configuration) extends Ap
   override val vatCorrespondenceChangeWebsiteUrl: String = "mock-change-website-url"
   override val vatCorrespondenceSendVerificationEmail: String = "send-verification"
   override val vatDesignatoryDetailsTradingNameUrl: String = "change-trading-name"
-  override val partyTypes: Seq[String] = Seq("2","4","7","11","50","52","59","62")
+  override val vatDesignatoryDetailsBusinessNameUrl: String = "change-business-name"
+  override def partyTypes: Seq[String] = Seq("2","4","7","11","50","52","59","62")
   override val govUkChangeVatRegistrationDetails: String = "mock-gov-uk-url"
   override val govUkSoftwareGuidanceUrl: String = "software-guidance"
   override val vatAgentClientLookupFrontendUrl: String = "/vaclf"

--- a/test/models/circumstanceInfo/CircumstanceDetailsModelSpec.scala
+++ b/test/models/circumstanceInfo/CircumstanceDetailsModelSpec.scala
@@ -21,9 +21,9 @@ import assets.PPOBAddressTestConstants.ppobAddressModelMax
 import assets.BankDetailsTestConstants.bankDetailsModelMax
 import models.returnFrequency.Mar
 import play.api.libs.json.Json
-import uk.gov.hmrc.play.test.UnitSpec
+import utils.TestUtil
 
-class CircumstanceDetailsModelSpec extends UnitSpec {
+class CircumstanceDetailsModelSpec extends TestUtil {
 
   "CircumstanceDetailsModel.pendingPPOBAddress" should{
 
@@ -58,6 +58,23 @@ class CircumstanceDetailsModelSpec extends UnitSpec {
 
       "there are pending return period changes" in {
         customerInformationNoPendingIndividual.pendingReturnPeriod shouldBe None
+      }
+    }
+  }
+
+  "calling .validPartyTypes" when {
+
+    "the party type is valid" should {
+
+      "return true" in {
+        customerInformationModelMaxOrganisation.validPartyType shouldBe true
+      }
+    }
+
+    "the party type is invalid" should {
+
+      "return false" in {
+        customerInformationModelMaxOrganisation.copy(partyType = Some("99")).validPartyType shouldBe false
       }
     }
   }

--- a/test/models/circumstanceInfo/CustomerDetailsSpec.scala
+++ b/test/models/circumstanceInfo/CustomerDetailsSpec.scala
@@ -50,12 +50,12 @@ class CustomerDetailsSpec extends UnitSpec {
       }
       "FirstName is present" should {
         "return 'Firstname'" in {
-          CustomerDetails(Some(firstName), None, None, None, None, overseasIndicator = false).userName shouldBe Some(s"$firstName")
+          customerDetailsMin.copy(firstName = Some(firstName)).userName shouldBe Some(s"$firstName")
         }
       }
       "LastName is present" should {
         "return 'Lastname'" in {
-          CustomerDetails(None, Some(lastName), None, None, None, overseasIndicator = false).userName shouldBe Some(s"$lastName")
+          customerDetailsMin.copy(lastName = Some(lastName)).userName shouldBe Some(s"$lastName")
         }
       }
       "No names are present" should {


### PR DESCRIPTION
Please ensure the following config PR is also merged: https://github.com/hmrc/app-config-base/pull/4658

This also requires the following acceptance test change: https://github.com/hmrc/change-vat-acceptance-tests/pull/210

As part of this work I have also strengthened the protective logic in the BusinessNameController. The `baseAccess` val contains a basic predicate that is aligned with the logic already in the view which decides whether to display the row in the first place. Copying this logic here means users that hit the URL directly are also handled correctly.