### PR TITLE
BTAT-9526 Enhanced ALF stub components

### DIFF
--- a/app/testOnly/models/StubAddressLookupJourneyConfig.scala
+++ b/app/testOnly/models/StubAddressLookupJourneyConfig.scala
@@ -61,7 +61,7 @@ object StubAddressLookupJourneyConfig {
 
   implicit def stubModel(implicit user: User[_], messagesApi: MessagesApi, config: AppConfig): StubAddressLookupJourneyConfig = {
     Json.toJson(AddressLookupJsonBuilder(
-      testOnly.controllers.routes.StubAddressLookupController.callback("1").url)
+      controllers.routes.BusinessAddressController.callback("").url)
     ).as[StubAddressLookupJourneyConfig]
   }
   implicit val confirmPageFormat: OFormat[ConfirmPage] = Json.format[ConfirmPage]

--- a/app/testOnly/views/StubAddressLookupView.scala.html
+++ b/app/testOnly/views/StubAddressLookupView.scala.html
@@ -93,9 +93,13 @@
                 </dl>
 
     @govukButton(Button(
-        href = Some(stubModel.options.continueUrl),
-        content = Text("Submit")
+        href = Some(controllers.routes.BusinessAddressController.callback("uk").url),
+        content = Text("Submit UK address")
     ))
-
+    @govukButton(Button(
+        href = Some(controllers.routes.BusinessAddressController.callback("overseas").url),
+        classes = "govuk-button--secondary",
+        content = Text("Submit overseas address")
+    ))
     }
 }

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -18,11 +18,9 @@ GET        /vat-through-software/account/test-only/vaclf-stub                   
 GET        /vat-through-software/account/test-only/vaclf-stub-unauth                  testOnly.controllers.StubAgentClientLookupController.unauth(redirectUrl: String)
 POST       /vat-through-software/account/test-only/vaclf-stub                         testOnly.controllers.StubAgentClientLookupController.post
 
-GET        /vat-through-software/account/test-only/address-lookup-stub/confirmed      testOnly.controllers.StubAddressLookupController.callback(id: String)
+GET        /vat-through-software/account/test-only/address-lookup-stub/api/confirmed  testOnly.controllers.StubAddressLookupController.getAddress(id: String)
 
 GET        /vat-through-software/account/test-only/address-lookup-stub/view           testOnly.controllers.StubAddressLookupController.show()
-# NOCSRF
-POST       /vat-through-software/account/test-only/address-lookup-stub/api/init       testOnly.controllers.StubAddressLookupController.initialiseJourney
 
 # NOCSRF
 POST       /vat-through-software/account/test-only/address-lookup-stub/api/v2/init    testOnly.controllers.StubAddressLookupController.initialiseJourney


### PR DESCRIPTION
As discussed in the huddle earlier, this now runs through more of our real code allowing for greater confidence when testing and submission of an address to VAT subscription. There are now two buttons on the test only page that simulate a user entering a UK and an overseas address.

These changes are purely to testOnly code so no app logic or unit tests are affected