### PR TITLE
BTAT-10033 Removed redundant vat-subscription feature switches; fixed ALF bug

### DIFF
--- a/app/models/customerAddress/AddressLookupJsonBuilder.scala
+++ b/app/models/customerAddress/AddressLookupJsonBuilder.scala
@@ -22,7 +22,6 @@ import play.api.i18n.{Lang, Messages, MessagesApi, MessagesImpl}
 import play.api.libs.json._
 import views.utils.ServiceNameUtil
 
-
 case class AddressLookupJsonBuilder(continueUrl: String)(implicit user: User[_], messagesApi: MessagesApi, config: AppConfig) {
 
   // general journey overrides
@@ -31,6 +30,7 @@ case class AddressLookupJsonBuilder(continueUrl: String)(implicit user: User[_],
   val conf: AppConfig = config
   val deskproServiceName: String = conf.contactFormServiceIdentifier
   val accessibilityFooterUrl: String = conf.accessibilityReportUrl
+  val relativeTimeoutUrl: String = conf.unauthorisedSignOutUrl.replace("http://localhost:9553", "")
 
   object Version2 {
 
@@ -43,7 +43,7 @@ case class AddressLookupJsonBuilder(continueUrl: String)(implicit user: User[_],
 
     val timeoutConfig: JsObject = Json.obj(
       "timeoutAmount" -> config.timeoutPeriod,
-      "timeoutUrl" -> config.unauthorisedSignOutUrl
+      "timeoutUrl" -> relativeTimeoutUrl
     )
     val selectPageLabels: Messages => JsObject = message => Json.obj(
       "title" -> message("address_lookupPage.selectPage.heading"),
@@ -82,42 +82,39 @@ case class AddressLookupJsonBuilder(continueUrl: String)(implicit user: User[_],
 
 object AddressLookupJsonBuilder {
 
-    implicit val writes: Writes[AddressLookupJsonBuilder] = new Writes[AddressLookupJsonBuilder] {
-      def writes(data: AddressLookupJsonBuilder): JsObject =
-        {
-          Json.obj(fields =
-            "version" -> 2,
-            "options" -> Json.obj(
-              "continueUrl" -> data.continueUrl,
-              "accessibilityFooterUrl" -> data.accessibilityFooterUrl,
-              "deskProServiceName" -> data.deskproServiceName,
-              "showPhaseBanner" -> data.showPhaseBanner,
-              "ukMode" -> data.ukMode,
-              "timeoutConfig" -> data.Version2.timeoutConfig
+    implicit val writes: Writes[AddressLookupJsonBuilder] = (data: AddressLookupJsonBuilder) => {
+      Json.obj(fields =
+        "version" -> 2,
+        "options" -> Json.obj(
+          "continueUrl" -> data.continueUrl,
+          "accessibilityFooterUrl" -> data.accessibilityFooterUrl,
+          "deskProServiceName" -> data.deskproServiceName,
+          "showPhaseBanner" -> data.showPhaseBanner,
+          "ukMode" -> data.ukMode,
+          "timeoutConfig" -> data.Version2.timeoutConfig
+        ),
+        "labels" -> Json.obj(
+          "en" -> Json.obj(
+            "appLevelLabels" -> Json.obj(
+              "navTitle" -> data.Version2.navTitle(data.Version2.eng),
+              "phaseBannerHtml" -> data.Version2.phaseBannerHtml(data.Version2.eng)
             ),
-            "labels" -> Json.obj(
-              "en" -> Json.obj(
-                "appLevelLabels" -> Json.obj(
-                  "navTitle" -> data.Version2.navTitle(data.Version2.eng),
-                  "phaseBannerHtml" -> data.Version2.phaseBannerHtml(data.Version2.eng)
-                ),
-                "selectPageLabels" -> data.Version2.selectPageLabels(data.Version2.eng),
-                "lookupPageLabels" -> data.Version2.lookupPageLabels(data.Version2.eng),
-                "confirmPageLabels" -> data.Version2.confirmPageLabels(data.Version2.eng),
-                "editPageLabels" -> data.Version2.editPageLabels(data.Version2.eng)
-              ),
-              "cy" -> Json.obj(
-                "appLevelLabels" -> Json.obj(
-                  "navTitle" -> data.Version2.navTitle(data.Version2.wel),
-                  "phaseBannerHtml" -> data.Version2.phaseBannerHtml(data.Version2.wel)
-                ),
-                "selectPageLabels" -> data.Version2.selectPageLabels(data.Version2.wel),
-                "lookupPageLabels" -> data.Version2.lookupPageLabels(data.Version2.wel),
-                "confirmPageLabels" -> data.Version2.confirmPageLabels(data.Version2.wel),
-                "editPageLabels" -> data.Version2.editPageLabels(data.Version2.wel)
-              )
-            )
+            "selectPageLabels" -> data.Version2.selectPageLabels(data.Version2.eng),
+            "lookupPageLabels" -> data.Version2.lookupPageLabels(data.Version2.eng),
+            "confirmPageLabels" -> data.Version2.confirmPageLabels(data.Version2.eng),
+            "editPageLabels" -> data.Version2.editPageLabels(data.Version2.eng)
+          ),
+          "cy" -> Json.obj(
+            "appLevelLabels" -> Json.obj(
+              "navTitle" -> data.Version2.navTitle(data.Version2.wel),
+              "phaseBannerHtml" -> data.Version2.phaseBannerHtml(data.Version2.wel)
+            ),
+            "selectPageLabels" -> data.Version2.selectPageLabels(data.Version2.wel),
+            "lookupPageLabels" -> data.Version2.lookupPageLabels(data.Version2.wel),
+            "confirmPageLabels" -> data.Version2.confirmPageLabels(data.Version2.wel),
+            "editPageLabels" -> data.Version2.editPageLabels(data.Version2.wel)
           )
-        }
+        )
+      )
     }
   }

--- a/app/testOnly/controllers/FeatureSwitchController.scala
+++ b/app/testOnly/controllers/FeatureSwitchController.scala
@@ -32,10 +32,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class FeatureSwitchController @Inject()(vatSubscriptionFeaturesConnector: VatSubscriptionFeaturesConnector,
-                                        featureSwitchView: FeatureSwitchView,
-                                        implicit val mcc: MessagesControllerComponents,
-                                        implicit val ec: ExecutionContext,
-                                        implicit val appConfig: AppConfig)
+                                        featureSwitchView: FeatureSwitchView)
+                                       (implicit mcc: MessagesControllerComponents,
+                                        ec: ExecutionContext,
+                                        appConfig: AppConfig)
   extends FrontendController(mcc) with I18nSupport with LoggerUtil {
 
   val featureSwitch: Action[AnyContent] = Action.async { implicit request =>

--- a/app/testOnly/forms/FeatureSwitchForm.scala
+++ b/app/testOnly/forms/FeatureSwitchForm.scala
@@ -25,17 +25,13 @@ object FeatureSwitchForm {
 
   val api1365Version: String = "Api1365Version"
   val api1363Version: String = "Api1363Version"
-  val enableAnnualAccounting: String = "enableAnnualAccounting"
-  val newStatusIndicators: String = "newStatusIndicators"
 
   val form: Form[FeatureSwitchModel] = Form(
     mapping(
       "vatSubscriptionFeatures" -> mapping(
-          api1363Version -> text.transform[Api1363Version](x => Api1363Version(x), _.id),
-          api1365Version -> text.transform[Api1365Version](x => Api1365Version(x), _.id),
-          enableAnnualAccounting -> boolean,
-          newStatusIndicators -> boolean
-        )(VatSubscriptionFeatureSwitchModel.apply)(VatSubscriptionFeatureSwitchModel.unapply),
+        api1363Version -> text.transform[Api1363Version](x => Api1363Version(x), _.id),
+        api1365Version -> text.transform[Api1365Version](x => Api1365Version(x), _.id)
+      )(VatSubscriptionFeatureSwitchModel.apply)(VatSubscriptionFeatureSwitchModel.unapply),
       ConfigKeys.stubAgentClientLookupFeature -> boolean,
       ConfigKeys.stubAddressLookupFeature -> boolean,
       ConfigKeys.allowOverseasChangeOfPPOBFeature -> boolean

--- a/app/testOnly/models/VatSubscriptionFeatureSwitchModel.scala
+++ b/app/testOnly/models/VatSubscriptionFeatureSwitchModel.scala
@@ -19,9 +19,7 @@ package testOnly.models
 import play.api.libs.json.{Format, Json}
 
 case class VatSubscriptionFeatureSwitchModel(Api1363Version: Api1363Version,
-                                             Api1365Version: Api1365Version,
-                                             enableAnnualAccounting: Boolean,
-                                             newStatusIndicators: Boolean)
+                                             Api1365Version: Api1365Version)
 
 object VatSubscriptionFeatureSwitchModel {
   implicit val format: Format[VatSubscriptionFeatureSwitchModel] = Json.format[VatSubscriptionFeatureSwitchModel]

--- a/app/testOnly/views/FeatureSwitchView.scala.html
+++ b/app/testOnly/views/FeatureSwitchView.scala.html
@@ -27,107 +27,84 @@
   @formWithCSRF(action = testOnly.controllers.routes.FeatureSwitchController.submitFeatureSwitch) {
 
     @govukCheckboxes(Checkboxes(
-        fieldset = Some(Fieldset(
-            legend = Some(Legend(
-            content = Text("Manage VAT Subscription Frontend Features"),
-            classes = "govuk-fieldset__legend--l",
-            isPageHeading = true
-        ))
-    )),
-    name = "featureSwitch",
-    items = Seq(
-        CheckboxItem(
-            id = Some(ConfigKeys.stubAgentClientLookupFeature),
-            name = Some(ConfigKeys.stubAgentClientLookupFeature),
-            content = Text("Stub Agent Client Lookup"),
-            value = "true",
-            checked = appConfig.features.stubAgentClientLookup()
-        ),
-        CheckboxItem(
-            id = Some(ConfigKeys.stubAddressLookupFeature),
-            name = Some(ConfigKeys.stubAddressLookupFeature),
-            content = Text("Stub Address Lookup"),
-            value = "true",
-            checked = appConfig.features.stubAddressLookup()
-        ),
-        CheckboxItem(
-            id= Some(ConfigKeys.allowOverseasChangeOfPPOBFeature),
-            name = Some(ConfigKeys.allowOverseasChangeOfPPOBFeature),
-            content = Text("Enable Overseas Change of PPOB"),
-            value = "true",
-            checked = appConfig.features.allowOverseasChangeOfPPOBEnabled()
-        )
-        )
-    ))
-
-    @govukCheckboxes(Checkboxes(
-        fieldset = Some(Fieldset(
-            legend = Some(Legend(
-            content = Text("Vat Subscription Backend Features"),
-            classes = "govuk-fieldset__legend--l",
-            isPageHeading = true
-        ))
-    )),
-    name = "featureSwitch",
-    items = Seq(
-        CheckboxItem(
-            id = Some("vatSubscriptionFeatures.enableAnnualAccounting"),
-            name = Some("vatSubscriptionFeatures.enableAnnualAccounting"),
-            content = Text("Enable Annual Accounting"),
-            value = "true",
-            checked = form("vatSubscriptionFeatures.enableAnnualAccounting").value.contains("true")
-        ),
-        CheckboxItem(
-            id = Some("vatSubscriptionFeatures.newStatusIndicators"),
-            name = Some("vatSubscriptionFeatures.newStatusIndicators"),
-            content = Text("Enable new status indicators"),
-            value = "true",
-            checked = form("vatSubscriptionFeatures.newStatusIndicators").value.contains("true")
-        )
-    )
-    ))
-
-@govukRadios(Radios(
-    fieldset = Some(Fieldset(
+      fieldset = Some(Fieldset(
         legend = Some(Legend(
-        content = Text("Which API1363 Version should be used?"),
-        classes = "govuk-fieldset__legend--s",
-        isPageHeading = false
-    ))
-        )),
-        name = "vatSubscriptionFeatures.Api1363Version",
-        items = Seq(
-            RadioItem(
-                id = Some("vatSubscriptionFeatures.Api1363Version"),
-                content = Text("Latest"),
-                value = Some("Latest"),
-                checked = form("vatSubscriptionFeatures.Api1363Version").value.contains("Latest")
-            )),
-        classes = "govuk-radios--inline"
+          content = Text("Manage VAT Subscription Frontend Features"),
+          classes = "govuk-fieldset__legend--l",
+          isPageHeading = true
         ))
+      )),
+      name = "featureSwitch",
+      items = Seq(
+        CheckboxItem(
+          id = Some(ConfigKeys.stubAgentClientLookupFeature),
+          name = Some(ConfigKeys.stubAgentClientLookupFeature),
+          content = Text("Stub Agent Client Lookup"),
+          value = "true",
+          checked = appConfig.features.stubAgentClientLookup()
+        ),
+        CheckboxItem(
+          id = Some(ConfigKeys.stubAddressLookupFeature),
+          name = Some(ConfigKeys.stubAddressLookupFeature),
+          content = Text("Stub Address Lookup"),
+          value = "true",
+          checked = appConfig.features.stubAddressLookup()
+        ),
+        CheckboxItem(
+          id= Some(ConfigKeys.allowOverseasChangeOfPPOBFeature),
+          name = Some(ConfigKeys.allowOverseasChangeOfPPOBFeature),
+          content = Text("Enable Overseas Change of PPOB"),
+          value = "true",
+          checked = appConfig.features.allowOverseasChangeOfPPOBEnabled()
+        )
+      )
+    ))
+
+    <h2 class="govuk-heading-l">Vat Subscription Backend Features</h2>
 
     @govukRadios(Radios(
-        fieldset = Some(Fieldset(
-            legend = Some(Legend(
-            content = Text("Which API1365 Version should be used?"),
-            classes = "govuk-fieldset__legend--s",
-            isPageHeading = false
+      fieldset = Some(Fieldset(
+        legend = Some(Legend(
+          content = Text("Which API1363 Version should be used?"),
+          classes = "govuk-fieldset__legend--s",
+          isPageHeading = false
         ))
-    )),
-    name = "vatSubscriptionFeatures.Api1365Version",
-    items = Seq(
+      )),
+      name = "vatSubscriptionFeatures.Api1363Version",
+      items = Seq(
         RadioItem(
-            id = Some("vatSubscriptionFeatures.Api1365Version"),
-            content = Text("Latest"),
-            value = Some("Latest"),
-            checked = form("vatSubscriptionFeatures.Api1365Version").value.contains("Latest")
-        )),
-    classes = "govuk-radios--inline"
+          id = Some("vatSubscriptionFeatures.Api1363Version"),
+          content = Text("Latest"),
+          value = Some("Latest"),
+          checked = form("vatSubscriptionFeatures.Api1363Version").value.contains("Latest")
+        )
+      ),
+      classes = "govuk-radios--inline"
+    ))
+
+    @govukRadios(Radios(
+      fieldset = Some(Fieldset(
+        legend = Some(Legend(
+          content = Text("Which API1365 Version should be used?"),
+          classes = "govuk-fieldset__legend--s",
+          isPageHeading = false
+        ))
+      )),
+      name = "vatSubscriptionFeatures.Api1365Version",
+      items = Seq(
+        RadioItem(
+          id = Some("vatSubscriptionFeatures.Api1365Version"),
+          content = Text("Latest"),
+          value = Some("Latest"),
+          checked = form("vatSubscriptionFeatures.Api1365Version").value.contains("Latest")
+        )
+      ),
+      classes = "govuk-radios--inline"
     ))
 
     @govukButton(Button(
-        content = Text("Submit")
+      content = Text("Submit")
     ))
 
-    }
+  }
 }


### PR DESCRIPTION
The ALF issue was due to a recent commit they made which requires timeoutUrl to be a relative URL: https://github.com/hmrc/address-lookup-frontend/commit/e22a2b7c1075ad25d044fb98078ac171d3772b62

This caused our local ALF handoff to fail. The cleanest solution I found was simply to String replace the GG host. Unfortunately due to the relative URL restrictions, we're locked into the ALF frontend localhost and so we can't set it to anything meaningful that will redirect to a sign in page or back to our service, so it looks to me as though we'll have to settle for a non-sensical timeout URL. Not ideal but once again this only affects local and not something that will affect any tests. 

Let me know if you have any better ideas.